### PR TITLE
Fix ambiguous log use statement

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,4 @@
-use log::{Level, LevelFilter, Metadata, Record};
+use ::log::{Level, LevelFilter, Metadata, Record};
 
 use esp_idf_sys::*;
 

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use alloc::sync::Arc;
 
 use cstr_core::CString;
-use log::*;
+use ::log::*;
 
 use mutex_trait::*;
 

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use log::*;
+use ::log::*;
 
 use mutex_trait::*;
 

--- a/src/ota.rs
+++ b/src/ota.rs
@@ -4,7 +4,7 @@ use core::ptr;
 extern crate alloc;
 use alloc::vec;
 
-use log::*;
+use ::log::*;
 
 use mutex_trait::*;
 

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,6 +1,6 @@
 use core::{mem, ptr, time::Duration};
 
-use log::*;
+use ::log::*;
 
 #[cfg(feature = "std")]
 use std::sync::*;

--- a/src/sysloop.rs
+++ b/src/sysloop.rs
@@ -1,4 +1,4 @@
-use log::*;
+use ::log::*;
 
 use mutex_trait::*;
 

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -5,7 +5,7 @@ use alloc::sync::Arc;
 use alloc::vec;
 
 use enumset::*;
-use log::*;
+use ::log::*;
 
 use mutex_trait::Mutex;
 


### PR DESCRIPTION
When using this crate with the latest nightly, I was getting an error about the ambiguous `log` uses. It didn't know whether to refer to the crate's `log` module, or the `log` dependency.
This PR fixes that.