### PR TITLE
feat: sntp 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ pub mod nvs_storage;
 ))]
 pub mod ota;
 pub mod ping;
+#[cfg(feature = "alloc")]
+pub mod sntp;
 pub mod sysloop;
 pub mod time;
 #[cfg(feature = "alloc")] // TODO: Expose a subset which does not require "alloc"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod httpd;
 #[cfg(feature = "alloc")]
 // TODO: Ideally should not need "alloc" (also for performance reasons)
 pub mod log;
+pub mod misc;
 #[cfg(esp_idf_config_lwip_ipv4_napt)]
 pub mod napt;
 pub mod netif;
@@ -43,6 +44,7 @@ pub mod nvs_storage;
 pub mod ota;
 pub mod ping;
 pub mod sysloop;
+pub mod time;
 #[cfg(feature = "alloc")] // TODO: Expose a subset which does not require "alloc"
 pub mod wifi;
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,0 +1,11 @@
+use esp_idf_sys::*;
+
+pub fn get_default_efuse_mac() -> Result<[u8; 6], EspError> {
+    let mut mac = [0; 6];
+    unsafe { esp!(esp_efuse_mac_get_default(mac.as_mut_ptr()))? }
+    Ok(mac)
+}
+
+pub fn restart() {
+    unsafe { esp_restart() };
+}

--- a/src/private/cstr.rs
+++ b/src/private/cstr.rs
@@ -12,6 +12,7 @@ extern crate alloc;
 
 #[cfg(feature = "alloc")]
 pub fn set_str(buf: &mut [u8], s: &str) {
+    assert!(s.len() < buf.len());
     let cs = CString::new(s).unwrap();
     let ss: &[u8] = cs.as_bytes_with_nul();
     buf[..ss.len()].copy_from_slice(ss);

--- a/src/private/mod.rs
+++ b/src/private/mod.rs
@@ -1,6 +1,7 @@
 pub mod common;
 pub mod cstr;
 pub mod net;
+pub mod wait;
 
 mod stubs;
 

--- a/src/private/wait.rs
+++ b/src/private/wait.rs
@@ -1,0 +1,97 @@
+use core::time::Duration;
+#[cfg(feature = "std")]
+use std::sync::{Condvar, Mutex};
+
+use embedded_svc::mutex::Mutex as _;
+#[cfg(not(feature = "std"))]
+use esp_idf_sys::*;
+
+#[cfg(not(feature = "std"))]
+use super::time::micros_since_boot;
+
+pub struct Waiter {
+    #[cfg(feature = "std")]
+    cvar: Condvar,
+    #[cfg(feature = "std")]
+    running: Mutex<bool>,
+    #[cfg(not(feature = "std"))]
+    running: EspMutex<bool>,
+}
+
+impl Waiter {
+    pub fn new() -> Self {
+        Waiter {
+            #[cfg(feature = "std")]
+            cvar: Condvar::new(),
+            #[cfg(feature = "std")]
+            running: Mutex::new(false),
+            #[cfg(not(feature = "std"))]
+            running: EspMutex::new(false),
+        }
+    }
+
+    pub fn start(&self) {
+        self.running.with_lock(|running| *running = true);
+    }
+
+    #[cfg(feature = "std")]
+    pub fn wait(&self) {
+        if !self.running.with_lock(|running| *running) {
+            return;
+        }
+
+        let _running = self
+            .cvar
+            .wait_while(self.running.lock().unwrap(), |running| *running)
+            .unwrap();
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn wait(&self) {
+        while self.running.with_lock(|running| *running) {
+            unsafe { vTaskDelay(500) };
+        }
+    }
+
+    /// return = !timeout (= success)
+    #[cfg(feature = "std")]
+    pub fn wait_timeout(&self, dur: Duration) -> bool {
+        if !self.running.with_lock(|running| *running) {
+            return true;
+        }
+
+        let (_running, res) = self
+            .cvar
+            .wait_timeout_while(self.running.lock().unwrap(), dur, |running| *running)
+            .unwrap();
+
+        return !res.timed_out();
+    }
+
+    /// return = !timeout (= success)
+    #[cfg(not(feature = "std"))]
+    pub fn wait_timeout(&self, dur: Duration) {
+        let now = micros_since_boot();
+        let end = now + dur.as_micros();
+
+        while self.running.with_lock(|running| *running) {
+            if micros_since_boot() > end {
+                return false;
+            }
+            unsafe { vTaskDelay(500) };
+        }
+
+        return true;
+    }
+
+    #[cfg(feature = "std")]
+    pub fn notify(&self) {
+        *self.running.lock().unwrap() = false;
+        self.cvar.notify_all();
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn notify(&self) {
+        self.running.with_lock(|running| *running = false);
+    }
+}

--- a/src/sntp.rs
+++ b/src/sntp.rs
@@ -1,0 +1,191 @@
+use core::{time::Duration};
+
+use anyhow::*;
+use log::*;
+use mutex_trait::Mutex;
+
+use esp_idf_sys::*;
+
+use crate::private::{cstr::CString, wait::Waiter};
+
+const SNTP_SERVER_NUM: usize = SNTP_MAX_SERVERS as usize;
+
+pub enum OperatingMode {
+    Poll,
+    ListenOnly,
+}
+
+impl From<u8_t> for OperatingMode {
+    fn from(from: u8_t) -> Self {
+        match from as u32 {
+            SNTP_OPMODE_POLL => OperatingMode::Poll,
+            SNTP_OPMODE_LISTENONLY => OperatingMode::ListenOnly,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<OperatingMode> for u8_t {
+    fn from(from: OperatingMode) -> Self {
+        match from {
+            OperatingMode::Poll => SNTP_OPMODE_POLL as u8_t,
+            OperatingMode::ListenOnly => SNTP_OPMODE_LISTENONLY as u8_t,
+        }
+    }
+}
+
+pub enum SyncMode {
+    Smooth,
+    Immediate,
+}
+
+impl From<sntp_sync_mode_t> for SyncMode {
+    #[allow(non_upper_case_globals)]
+    fn from(from: sntp_sync_mode_t) -> Self {
+        match from {
+            sntp_sync_mode_t_SNTP_SYNC_MODE_SMOOTH => SyncMode::Smooth,
+            sntp_sync_mode_t_SNTP_SYNC_MODE_IMMED => SyncMode::Immediate,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<SyncMode> for sntp_sync_mode_t {
+    fn from(from: SyncMode) -> Self {
+        match from {
+            SyncMode::Smooth => sntp_sync_mode_t_SNTP_SYNC_MODE_SMOOTH,
+            SyncMode::Immediate => sntp_sync_mode_t_SNTP_SYNC_MODE_IMMED,
+        }
+    }
+}
+
+pub enum SyncStatus {
+    Reset,
+    Completed,
+    InProgress,
+}
+
+impl From<sntp_sync_status_t> for SyncStatus {
+    #[allow(non_upper_case_globals)]
+    fn from(from: sntp_sync_status_t) -> Self {
+        match from {
+            sntp_sync_status_t_SNTP_SYNC_STATUS_RESET => SyncStatus::Reset,
+            sntp_sync_status_t_SNTP_SYNC_STATUS_COMPLETED => SyncStatus::Completed,
+            sntp_sync_status_t_SNTP_SYNC_STATUS_IN_PROGRESS => SyncStatus::InProgress,
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub struct SntpConf {
+    pub servers: [String; SNTP_SERVER_NUM],
+    pub operating_mode: OperatingMode,
+    pub sync_mode: SyncMode,
+}
+
+impl Default for SntpConf {
+    fn default() -> Self {
+        let mut servers: [String; SNTP_SERVER_NUM] = Default::default();
+        // only 0-3 are valid ntp pool domain names
+        for i in 0..SNTP_SERVER_NUM.min(4) {
+            servers[i] = format!("{}.pool.ntp.org", i);
+        }
+
+        SntpConf {
+            servers,
+            operating_mode: OperatingMode::Poll,
+            sync_mode: SyncMode::Immediate,
+        }
+    }
+}
+
+static mut TAKEN: EspMutex<bool> = EspMutex::new(false);
+static mut WAITER: Option<Waiter> = None;
+
+pub struct EspSntp {
+    // Needs to be kept around because the C bindings only have a pointer.
+    _sntp_servers: [CString; SNTP_SERVER_NUM],
+}
+
+impl EspSntp {
+    pub fn new(conf: SntpConf) -> Result<Self> {
+        unsafe {
+            TAKEN.lock(|taken| {
+                if *taken {
+                    Err(EspError::from(ESP_ERR_INVALID_STATE as i32).unwrap().into())
+                } else {
+                    let sntp = Self::init(conf)?;
+
+                    *taken = true;
+                    Ok(sntp)
+                }
+            })
+        }
+    }
+
+    unsafe fn init(conf: SntpConf) -> Result<Self> {
+        info!("Initializing");
+
+        sntp_setoperatingmode(u8_t::from(conf.operating_mode));
+        sntp_set_sync_mode(sntp_sync_mode_t::from(conf.sync_mode));
+
+        let mut c_servers: [CString; SNTP_SERVER_NUM] = Default::default();
+        for (i, s) in conf.servers.iter().enumerate() {
+            let c_server = CString::new(s.as_str()).unwrap();
+            sntp_setservername(i as u8, c_server.as_ptr());
+            c_servers[i] = c_server;
+        }
+
+        let sntp = EspSntp {
+            _sntp_servers: c_servers,
+        };
+
+        sntp_set_time_sync_notification_cb(Some(Self::sync_cb));
+        sntp_init();
+
+        let waiter = WAITER.insert(Waiter::new());
+        waiter.start();
+
+        let c_tz = CString::new("TZ")?;
+        let c_tz_val = CString::new("UTC")?;
+        setenv(c_tz.as_ptr(), c_tz_val.as_ptr(), 1);
+        tzset();
+
+        info!("Initialization complete");
+        Ok(sntp)
+    }
+
+    pub fn get_sync_status(&self) -> SyncStatus {
+        SyncStatus::from(unsafe { sntp_get_sync_status() })
+    }
+
+    /// Wait for SNTP to be synced or the duration passed, returns true if it synced, false for a timeout.
+    pub fn wait_for_sync(&self, dur: Duration) -> bool {
+        info!("Waiting for system time to be set");
+
+        unsafe { WAITER.as_ref().unwrap().wait_timeout(dur) }
+    }
+
+    unsafe extern "C" fn sync_cb(tv: *mut esp_idf_sys::timeval) {
+        debug!(
+            "Sync cb called: sec: {}, usec: {}",
+            (*tv).tv_sec,
+            (*tv).tv_usec,
+        );
+
+        WAITER.as_ref().unwrap().notify();
+    }
+}
+
+impl Drop for EspSntp {
+    fn drop(&mut self) {
+        unsafe {
+            TAKEN.lock(|taken| {
+                sntp_stop();
+                *taken = false;
+            });
+        }
+
+        info!("Dropped");
+    }
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,7 @@
+use core::convert::TryInto;
+
+use esp_idf_sys::*;
+
+pub fn micros_since_boot() -> u64 {
+    unsafe { esp_timer_get_time() }.try_into().unwrap()
+}


### PR DESCRIPTION
Will get the time from a NTP server

```rs
let sntp = EspSntp::new(SntpConf::default())?;
sntp.wait_for_sync(Duration::from_secs(30));
```

After you can use the usual time APIs and get the real-world time (i.e. `std::time::SystemTime::now()`)

Depends on #13