### PR TITLE
An error occurred when sdkconfig set CONFIG_LOG_DEFAULT_LEVEL_NONE=y 

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -68,7 +68,7 @@ unsafe impl Sync for EspLogger {}
 
 impl EspLogger {
     pub fn initialize_default() {
-        log::set_logger(&LOGGER)
+        ::log::set_logger(&LOGGER)
             .map(|()| LOGGER.initialize())
             .unwrap();
     }


### PR DESCRIPTION
function or associated item not found in `esp_idf_sys::log`