### PR TITLE
Disable http server if std not available.

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,4 @@
 #[cfg(esp_idf_comp_esp_http_client_enabled)]
 pub mod client;
-#[cfg(esp_idf_comp_esp_http_server_enabled)]
+#[cfg(all(esp_idf_comp_esp_http_server_enabled, feature = "std"))]
 pub mod server;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,6 +1,8 @@
 extern crate alloc;
 use alloc::borrow::Cow;
 use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::string::ToString;
 
 use ::log::*;
 


### PR DESCRIPTION
Currently [embedded-svc](https://github.com/esp-rs/embedded-svc/blob/master/src/http.rs#L6) disables the `http::server` module is std isn't enabled.

Until it supports `no-std`, it should be disabled here as well.