### PR TITLE
HTTP Client: Use per-client event handlers

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -176,7 +176,7 @@ pub struct EspHttpRequest<'a> {
 }
 
 impl<'a> EspHttpRequest<'a> {
-    fn register_handler(&self, handler: &mut impl Fn(&esp_http_client_event_t) + 'static) {
+    fn register_handler(&self, handler: &mut (impl Fn(&esp_http_client_event_t) + 'static)) {
         *self.event_handler = Some(unsafe {
             // SAFETY: reference to pointer cast always results in a non-null pointer.
             NonNull::new_unchecked(handler as *mut _)

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -4,7 +4,7 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::string::ToString;
 
-use ::log::*;
+use log::*;
 
 #[cfg(feature = "std")]
 pub use std::ffi::{CStr, CString};
@@ -113,10 +113,12 @@ impl EspHttpClient {
         match unsafe { event.as_mut() } {
             Some(event) => {
                 let event_handler = unsafe {
-                    (event.user_data as *const Option<NonNull<dyn Fn(&esp_http_client_event_t)>>).as_ref()
+                    (event.user_data as *const Option<NonNull<dyn Fn(&esp_http_client_event_t)>>)
+                        .as_ref()
+                        .unwrap()
                 };
-                if let Some(opt_handler) = event_handler {
-                    let handler = unsafe { opt_handler.unwrap().as_mut() };
+                if let Some(mut opt_handler) = *event_handler {
+                    let handler = unsafe { opt_handler.as_mut() };
                     handler(event);
                 }
 


### PR DESCRIPTION
This PR indents to replace the global shared BTreeMap with private event handler pointers, thus saving a lock and a lookup.
