### PR TITLE
fix sending data in HttpClient

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -295,9 +295,13 @@ impl<'a> Write for EspHttpRequest<'a> {
     type Error = EspError;
 
     fn do_write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        esp!(unsafe { esp_http_client_write(self.client.raw, buf.as_ptr() as _, buf.len() as _) })?;
+        let result =
+            unsafe { esp_http_client_write(self.client.raw, buf.as_ptr() as _, buf.len() as _) };
+        if result < 0 {
+            esp!(result)?;
+        }
 
-        Ok(buf.len())
+        Ok(result as _)
     }
 }
 


### PR DESCRIPTION
I noticed that sending data using the http client was broken. The root cause is the error handling in `do_write`. `esp_http_client_write` returns the number of bytes written, but the `esp!` macro converts every non-zero return code into an error.

In `do_read`, the implementation is correct already. I used the error handling from `do_read` in `do_write` now, which should be correct. I already tried the changes and they seem to work fine.