### PR TITLE
HTTP header keys are case-insensitive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = ["alloc", "anyhow/std", "log/std", "esp-idf-sys/std", "esp-idf-hal/std", "embedded-svc/std"]
 alloc = ["cstr_core/alloc", "anyhow", "embedded-svc/alloc"]
 
-experimental = ["embedded-svc/experimental", "esp-idf-hal/experimental"]
+experimental = ["embedded-svc/experimental", "esp-idf-hal/experimental", "uncased"]
 
 [dependencies]
 enumset = { version = "1", default-features = false }
@@ -27,6 +27,7 @@ anyhow = { version = "1", default-features = false, optional = true }
 embedded-svc = { version = "0.16.3", default-features = false }
 esp-idf-sys = { version = "0.30", default-features = false, features = ["pio"] }
 esp-idf-hal = { version = "0.32.4", default-features = false, features = ["esp-idf-sys", "embedded-svc-mutex"] }
+uncased = { version = "0.9.6", optional = true }
 
 [build-dependencies]
 embuild = "0.28"

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -12,6 +12,8 @@ use embedded_svc::io::{Read, Write};
 
 use esp_idf_sys::*;
 
+use uncased::{Uncased, UncasedStr};
+
 use crate::private::common::Newtype;
 use crate::private::cstr::*;
 
@@ -209,12 +211,12 @@ pub struct EspHttpRequestWrite<'a> {
 }
 
 impl<'a> EspHttpRequestWrite<'a> {
-    fn fetch_headers(&mut self) -> Result<BTreeMap<String, String>, EspError> {
+    fn fetch_headers(&mut self) -> Result<BTreeMap<Uncased<'static>, String>, EspError> {
         let mut headers = BTreeMap::new();
 
         loop {
             // TODO: Implement a mechanism where the client can declare in which header it is interested
-            let headers_ptr = &mut headers as *mut BTreeMap<String, String>;
+            let headers_ptr = &mut headers as *mut BTreeMap<Uncased, String>;
 
             let handler = move |event: &esp_http_client_event_t| {
                 if event.event_id == esp_http_client_event_id_t_HTTP_EVENT_ON_HEADER {
@@ -222,7 +224,7 @@ impl<'a> EspHttpRequestWrite<'a> {
                         // TODO: Replace with a proper conversion from ISO-8859-1 to UTF8
 
                         headers_ptr.as_mut().unwrap().insert(
-                            from_cstr_ptr(event.header_key).into_owned(),
+                            Uncased::from(from_cstr_ptr(event.header_key).into_owned()),
                             from_cstr_ptr(event.header_value).into_owned(),
                         );
                     }
@@ -313,7 +315,7 @@ impl<'a> Write for EspHttpRequestWrite<'a> {
 
 pub struct EspHttpResponse<'a> {
     client: &'a mut EspHttpClient,
-    headers: BTreeMap<String, String>,
+    headers: BTreeMap<Uncased<'static>, String>,
 }
 
 impl<'a> Response for EspHttpResponse<'a> {
@@ -335,7 +337,7 @@ impl<'a> Headers for EspHttpResponse<'a> {
             self.content_len().map(|l| Cow::Owned(l.to_string()))
         } else {
             self.headers
-                .get(name.as_ref())
+                .get(UncasedStr::new(name.as_ref()))
                 .map(|s| Cow::Borrowed(s.as_str()))
         }
     }


### PR DESCRIPTION
Use the `uncased` crate when HTTP client is enabled to ensure this.

Fixes #39 in my brief test of my project, tested on an ESP32-C3.