### PR TITLE
Use fully qualified path for c_void in crt_bundle_attach

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -66,7 +66,7 @@ pub struct EspHttpClientConfiguration {
 
     pub use_global_ca_store: bool,
     #[cfg(not(esp_idf_version = "4.3"))]
-    pub crt_bundle_attach: Option<unsafe extern "C" fn(conf: *mut c_void) -> esp_err_t>,
+    pub crt_bundle_attach: Option<unsafe extern "C" fn(conf: *mut c_types::c_void) -> esp_err_t>,
 }
 
 #[allow(clippy::type_complexity)]

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -60,7 +60,7 @@ pub struct MqttClientConfiguration<'a> {
     pub use_global_ca_store: bool,
     pub skip_cert_common_name_check: bool,
     #[cfg(not(esp_idf_version = "4.3"))]
-    pub crt_bundle_attach: Option<unsafe extern "C" fn(conf: *mut c_void) -> esp_err_t>,
+    pub crt_bundle_attach: Option<unsafe extern "C" fn(conf: *mut c_types::c_void) -> esp_err_t>,
     // TODO: Future
 
     // pub cert_pem: &'a [u8],


### PR DESCRIPTION
Excited to test out the mqtt client, but found this error when using esp-idf v4.4.