### PR TITLE
fix for mqtt keepalive

### DIFF
--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -138,9 +138,9 @@ impl<'a> From<&MqttClientConfiguration<'a>> for (esp_mqtt_client_config_t, RawCs
 
         if let Some(keep_alive_interval) = conf.keep_alive_interval {
             c_conf.keepalive = keep_alive_interval.as_secs() as _;
-            c_conf.keepalive = true as _;
+            c_conf.disable_keepalive = false as _;
         } else {
-            c_conf.keepalive = false as _;
+            c_conf.disable_keepalive = true as _;
         }
 
         if let Some(reconnect_timeout) = conf.reconnect_timeout {


### PR DESCRIPTION
Previous code would set keepalive interval to 1 second if a keepalive value was provided (or just not explicitly set to None).

One issue I've noticed with Mosquitto, if you explicitly set keep_alive_interval in MqttClientConfiguration to None, the esp32 will fail to connect. I'm not sure of the cause of this issue (I'm new to MQTT).