### PR TITLE
MQTT username/password

### DIFF
--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -58,6 +58,9 @@ pub struct MqttClientConfiguration<'a> {
     pub buffer_size: usize,
     pub out_buffer_size: usize,
 
+    pub username: Option<&'a str>,
+    pub password: Option<&'a str>,
+
     pub use_global_ca_store: bool,
     pub skip_cert_common_name_check: bool,
     #[cfg(not(esp_idf_version = "4.3"))]
@@ -98,6 +101,9 @@ impl<'a> Default for MqttClientConfiguration<'a> {
             buffer_size: 0,
             out_buffer_size: 0,
 
+            username: None,
+            password: None,
+
             use_global_ca_store: false,
             skip_cert_common_name_check: false,
 
@@ -128,6 +134,9 @@ impl<'a> From<&MqttClientConfiguration<'a>> for (esp_mqtt_client_config_t, RawCs
             task_stack: conf.task_stack as _,
             buffer_size: conf.buffer_size as _,
             out_buffer_size: conf.out_buffer_size as _,
+
+            username: cstrs.as_nptr(conf.username),
+            password: cstrs.as_nptr(conf.password),
 
             use_global_ca_store: conf.use_global_ca_store,
             skip_cert_common_name_check: conf.skip_cert_common_name_check,


### PR DESCRIPTION
Thanks for all your work on esp-rs! This trivial PR adds MQTT username / password support.

With this change, the [Ably Realtime](https://ably.com/pub-sub-messaging) cloud service seems to work well, using the [recommended configuration](https://ably.com/documentation/mqtt):

 - `mqtts://mqtt.ably.io:8883`
 - username and password from the API key
 - `MqttProtocolVersion::V3_1_1`
 - keepalive interval between 15 and 60 seconds