### PR TITLE
Fix ambiguous `log` import

### DIFF
--- a/src/espnow.rs
+++ b/src/espnow.rs
@@ -1,4 +1,4 @@
-use log::info;
+use ::log::info;
 
 use esp_idf_hal::mutex::Mutex;
 use esp_idf_sys::*;

--- a/src/sntp.rs
+++ b/src/sntp.rs
@@ -1,7 +1,7 @@
 extern crate alloc;
 use alloc::string::String;
 
-use log::*;
+use ::log::*;
 
 use esp_idf_hal::mutex;
 


### PR DESCRIPTION
Seems to be a leftover from https://github.com/esp-rs/esp-idf-svc/pull/5.

Otherwise it may conflict with the one imported from esp_idf_sys.

```
error[E0659]: `log` is ambiguous
 --> /esp-idf-svc-0.39.1/src/sntp.rs:4:5
  |
4 | use log::*;
  |     ^^^ ambiguous name
  |
  = note: ambiguous because of multiple potential import sources
  = note: `log` could refer to a crate passed with `--extern`
  = help: use `::log` to refer to this crate unambiguously
note: `log` could also refer to the struct imported here
 --> /esp-idf-svc-0.39.1/src/sntp.rs:8:5
  |
8 | use esp_idf_sys::*;
  |     ^^^^^^^^^^^^^^
  = help: use `self::log` to refer to this struct unambiguously

For more information about this error, try `rustc --explain E0659`.
```