### PR TITLE
Fix espnow.rs to build under no-std

### DIFF
--- a/src/espnow.rs
+++ b/src/espnow.rs
@@ -1,5 +1,7 @@
 use log::info;
 
+use alloc::boxed::Box;
+
 use esp_idf_hal::mutex::Mutex;
 use esp_idf_sys::*;
 
@@ -144,7 +146,7 @@ impl EspNowClient {
     }
 
     extern "C" fn send_callback(mac_addr: *const u8, status: esp_now_send_status_t) {
-        let c_mac = unsafe { std::slice::from_raw_parts(mac_addr, 6usize) };
+        let c_mac = unsafe { core::slice::from_raw_parts(mac_addr, 6usize) };
 
         if let Some(ref mut callback) = *SEND_CALLBACK.lock() {
             callback(c_mac, status.into())
@@ -154,8 +156,8 @@ impl EspNowClient {
     }
 
     extern "C" fn recv_callback(mac_addr: *const u8, data: *const u8, data_len: c_types::c_int) {
-        let c_mac = unsafe { std::slice::from_raw_parts(mac_addr, 6usize) };
-        let c_data = unsafe { std::slice::from_raw_parts(data, data_len as usize) };
+        let c_mac = unsafe { core::slice::from_raw_parts(mac_addr, 6usize) };
+        let c_data = unsafe { core::slice::from_raw_parts(data, data_len as usize) };
 
         if let Some(ref mut callback) = *RECV_CALLBACK.lock() {
             callback(c_mac, c_data)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,12 @@
 #[macro_use]
 extern crate alloc;
 
+#[cfg(all(
+    feature = "alloc",
+    esp_idf_comp_esp_eth_enabled,
+    esp_idf_comp_esp_event_enabled,
+    esp_idf_comp_esp_netif_enabled
+))]
 pub mod espnow;
 #[cfg(all(
     feature = "alloc",


### PR DESCRIPTION
The recent addition of ESPNow had references to `std` and `Box` that weren't hidden behind cfg flags. This PR changes `std` to `core` and also add the `alloc` and network checks to `lib.rs`.