### PR TITLE
Empty SSID for client config means not to connect

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -401,8 +401,7 @@ impl EspWifi {
             Self::netif_unbind(shared.sta_netif.as_mut())?;
             shared.client_ip_conf = None;
             shared.sta_netif = None;
-        }
-        else {
+        } else {
             self.set_client_ip_conf(&conf.ip_conf)?;
         }
 


### PR DESCRIPTION
This change makes it possible to set Mixed or Client mode without specifying a Wifi to connect to (as in passing Default::default()). Correct me if I am wrong but I believe this change would later make it possible to make a version of Wifi::scan() that does not need to restart the wifi.

```rust
let mut wifi = esp_wifi::EspWifi::new(...);

wifi.set_configuration(&wifi::Configuration::Client(
    Default::default()
));
```

or

```rust
let mut wifi = esp_wifi::EspWifi::new(...);
let my_ap_config = ...;

wifi.set_configuration(&wifi::Configuration::Mixed(
    Default::default(),
    my_ap_config,
));
```

Tested and seems to work on an esp32-wroom-32D
```
Chip type:         ESP32 (revision 1)
Crystal frequency: 40MHz
Flash size:        4MB
Features:          WiFi, BT, Dual Core, Coding Scheme None
```