### PR TITLE
Add `stats()` function for nvs_storage

### DIFF
--- a/src/nvs_storage.rs
+++ b/src/nvs_storage.rs
@@ -18,6 +18,8 @@ enum EspNvsRef {
     Nvs(Arc<EspNvs>),
 }
 
+pub type NvsStats = nvs_stats_t;
+
 pub struct EspNvsStorage(EspNvsRef, nvs_handle_t);
 
 impl EspNvsStorage {
@@ -66,6 +68,14 @@ impl EspNvsStorage {
         })?;
 
         Ok(Self(EspNvsRef::Nvs(nvs), handle))
+    }
+
+    pub fn stats(&self) -> Result<NvsStats, EspError> {
+        let mut nvs_stats = NvsStats::default();
+
+        esp!(unsafe { nvs_get_stats(ptr::null_mut(), &mut nvs_stats as *mut nvs_stats_t) })?;
+
+        Ok(nvs_stats)
     }
 }
 


### PR DESCRIPTION
This maps to the `nvs_get_stats()` function from the ESP IDF.