### PR TITLE
log: implementation with no allocations

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -117,10 +117,10 @@ impl EspLogger {
 
     fn should_log(record: &Record) -> bool {
         let level = Newtype::<esp_log_level_t>::from(record.level()).0;
-        let min_level = unsafe {
+        let max_level = unsafe {
             esp_log_level_get(b"rust-logging\0" as *const u8 as *const _) // TODO: use record target?
         };
-        level <= min_level
+        level <= max_level
     }
 }
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,9 +1,26 @@
+use core::fmt::Write;
+
 use ::log::{Level, LevelFilter, Metadata, Record};
 
 use esp_idf_sys::*;
 
 use crate::private::common::*;
 use crate::private::cstr::*;
+
+/// Exposes the newlib stdout file descriptor to allow writing formatted
+/// messages to stdout without a std dependency or allocation
+struct EspStdout;
+
+impl core::fmt::Write for EspStdout {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let stdout = unsafe { __getreent().as_mut() }.unwrap()._stdout;
+        let slice = s.as_bytes();
+        unsafe {
+            fwrite(slice.as_ptr() as *const _, 1, slice.len() as u32, stdout);
+        }
+        Ok(())
+    }
+}
 
 #[allow(non_upper_case_globals)]
 impl From<Newtype<esp_log_level_t>> for LevelFilter {
@@ -132,22 +149,24 @@ impl ::log::Log for EspLogger {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) && Self::should_log(record) {
             if let Some(color) = Self::get_color(record.level()) {
-                println!(
-                    "\x1b[0;{}m{} ({}) {}: {}\x1b[0m",
+                write!(EspStdout,
+                    "\x1b[0;{}m{} ({}) {}: {}\x1b[0m\n",
                     color,
                     Self::get_marker(record.metadata().level()),
                     unsafe { esp_log_timestamp() },
                     record.metadata().target(),
                     record.args(),
-                );
+                )
+                .unwrap();
             } else {
-                println!(
-                    "{} ({}) {}: {}",
+                write!(EspStdout,
+                    "{} ({}) {}: {}\n",
                     Self::get_marker(record.metadata().level()),
                     unsafe { esp_log_timestamp() },
                     record.metadata().target(),
                     record.args(),
-                );
+                )
+                .unwrap();
             }
         }
     }


### PR DESCRIPTION
As noted in TODO, use esp_log_level_get to decide whether to log, then use println!() to directly write message, including no-alloc write of record.args().