### PR TITLE
add with_handle

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -613,7 +613,7 @@ impl<P> EspEth<P> {
         Ok(eth)
     }
 
-    pub fn with_handle<F, T>(&self, f: F) -> T
+    pub fn with_handle<F, T>(&mut self, f: F) -> T
     where
         F: FnOnce(esp_eth_handle_t) -> T,
     {

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -613,6 +613,13 @@ impl<P> EspEth<P> {
         Ok(eth)
     }
 
+    pub fn with_handle<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(esp_eth_handle_t) -> T,
+    {
+        self.waitable.get(|shared| f(shared.handle))
+    }
+
     pub fn with_netif<F, T>(&self, f: F) -> T
     where
         F: FnOnce(Option<&EspNetif>) -> T,


### PR DESCRIPTION
Add possibility to access the ethernet handle after initializing the driver. I needed this because I had to set a phy register.