### PR TITLE
fixed issue #94

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -338,6 +338,7 @@ impl EspHttpServer {
         for close_handler in &*close_handlers {
             (close_handler)(sockfd);
         }
+        esp_nofail!(unsafe { close(sockfd) });
     }
 }
 


### PR DESCRIPTION
This PR closes the raw socket as part of finishing processing a HTTP request. The callback close_fd() needs also to close the raw socket which was missed in the original implementation and resulted in a socket leak