### PR TITLE
Fix double stop() when an MQTT instance goes out of scope

### DIFF
--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -358,11 +358,6 @@ impl<P> Drop for EspMqttClient<P> {
             connection_state.close();
         }
 
-        // Best effort - stop if started
-        unsafe {
-            esp_mqtt_client_stop(self.raw_client);
-        }
-
         esp!(unsafe { esp_mqtt_client_destroy(self.raw_client) }).unwrap();
     }
 }


### PR DESCRIPTION
When I create an MQTT connection, and let the variable go out of scope, I get this error in the logs:

`W (912) MQTT_CLIENT: Client asked to stop, but was not started`

At first that scared me a bit, but I think the problem is that the MQTT client is stopped twice (and the warning is harmless).

https://github.com/esp-rs/esp-idf-svc/blob/1cad9a87d439d715681c323ddb8972a0bc70b6c5/src/mqtt/client.rs#L362-L366

First calls stop, after destroy. However, in the destroy function this happens:

https://github.com/espressif/esp-mqtt/blob/9a56b2f086cb43fe981fc92c80fb926081b180fb/mqtt_client.c#L827-L829

In other words, stop() is called twice, creating the warning in the logs.