### PR TITLE
Convert from u8 -> c_int

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -33,7 +33,7 @@ impl EspPing {
             interval_ms: conf.interval.as_millis() as u32,
             timeout_ms: conf.timeout.as_millis() as u32,
             data_size: conf.data_size,
-            tos: conf.tos,
+            tos: conf.tos.into(),
             target_addr: ip_addr_t {
                 u_addr: ip_addr__bindgen_ty_1 {
                     ip4: Newtype::<ip4_addr_t>::from(ip).0,


### PR DESCRIPTION
The `esp_ping_config_t` struct was [recently updated](https://github.com/espressif/esp-idf/commit/f8a4504bc5d153439bd34f6544aab1244143f421#diff-b60c65a810a67b50afef665dc83cfb0732012e846b5f8daaf5dcfd20c02ae912R70), and the `tos` field is now `int`, not `uint8_t`. The field is convered to a `c_types::c_int` in `bindings.rs`, and so the following error is thrown:


```rust
ryan@ryan-pc:/opt/rust-workspace/projects/esp32s2-workspace/main$ cargo +esp build
   Compiling embedded-io v0.3.0
   Compiling esp-idf-hal v0.38.0 (https://github.com/esp-rs/esp-idf-hal#7d9bec77)
   Compiling esp-idf-svc v0.42.0 (https://github.com/esp-rs/esp-idf-svc#1cad9a87)
   Compiling main v0.1.0 (/opt/rust-workspace/projects/esp32s2-workspace/main)
   Compiling embedded-svc v0.22.0
error[E0308]: mismatched types
  --> /home/ryan/.cargo/git/checkouts/esp-idf-svc-a28457b0e32c6283/1cad9a8/src/ping.rs:36:18
   |
36 |             tos: conf.tos,
   |                  ^^^^^^^^ expected `i32`, found `u8`

For more information about this error, try `rustc --explain E0308`.
```

Note that the `esp_ping_config_t` change has been applied to [`v4.4`](https://github.com/espressif/esp-idf/blob/release/v4.4/components/lwip/include/apps/ping/ping_sock.h#L70) and [`master`](https://github.com/espressif/esp-idf/blob/master/components/lwip/include/apps/ping/ping_sock.h#L62), but [`v5.0`](https://github.com/espressif/esp-idf/blob/release/v5.0/components/lwip/include/apps/ping/ping_sock.h#L70) is still using `uint8_t`.
