### PR TITLE
Ota function get_running_slot() retrieves boot-slot, not running-slot.

### DIFF
--- a/src/ota.rs
+++ b/src/ota.rs
@@ -218,7 +218,7 @@ impl ota::Ota for EspOta<Read> {
 
     fn get_running_slot(&self) -> Result<Self::Slot<'_>, Self::Error> {
         Ok(EspSlot(unsafe {
-            *esp_ota_get_boot_partition().as_ref().unwrap()
+            *esp_ota_get_running_partition().as_ref().unwrap()
         }))
     }
 


### PR DESCRIPTION
These functions are in fact the same till you change the boot-slot.
Only after that, they differ.

I assume this was an honest mistake, as `get_boot_slot` already calls `esp_ota_get_boot_partition`.