### PR TITLE
[ping] correct clippy lint rule name

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -28,7 +28,7 @@ impl EspPing {
         tracker: &mut Tracker<F>,
     ) -> Result<(), EspError> {
         #[allow(clippy::needless_update)]
-        #[allow(clippy::useless-conversion)]
+        #[allow(clippy::useless_conversion)]
         let config = esp_ping_config_t {
             count: conf.count,
             interval_ms: conf.interval.as_millis() as u32,


### PR DESCRIPTION
It looks like 4ba41cd7c introduced a clippy allowance that should have referenced the lint via underscore, rather than hyphen:
https://rust-lang.github.io/rust-clippy/master/#useless_conversion