### PR TITLE
#105 Add option to set a mac for an interface and use the default if none is set

### DIFF
--- a/src/netif.rs
+++ b/src/netif.rs
@@ -403,7 +403,7 @@ impl EspNetif {
     }
 
     pub fn set_mac(&mut self, mac: &[u8; 6]) -> Result<(), EspError> {
-        esp!(unsafe { esp_netif_set_mac(self.1, mac.clone().as_mut_ptr() as *mut _) })?;
+        esp!(unsafe { esp_netif_set_mac(self.1, mac.as_ptr() as *mut _) })?;
         Ok(())
     }
 

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -60,6 +60,7 @@ pub struct InterfaceConfiguration {
     pub route_priority: u32,
     pub ip_configuration: InterfaceIpConfiguration,
     pub interface_stack: InterfaceStack,
+    pub custom_mac: Option<[u8; 6]>,
 }
 
 impl Default for InterfaceConfiguration {
@@ -76,6 +77,7 @@ impl InterfaceConfiguration {
             route_priority: 60,
             ip_configuration: InterfaceIpConfiguration::Client(Default::default()),
             interface_stack: InterfaceStack::Eth,
+            custom_mac: None,
         }
     }
 
@@ -86,6 +88,7 @@ impl InterfaceConfiguration {
             route_priority: 50,
             ip_configuration: InterfaceIpConfiguration::Router(Default::default()),
             interface_stack: InterfaceStack::Eth,
+            custom_mac: None,
         }
     }
 
@@ -96,6 +99,7 @@ impl InterfaceConfiguration {
             route_priority: 100,
             ip_configuration: InterfaceIpConfiguration::Client(Default::default()),
             interface_stack: InterfaceStack::Sta,
+            custom_mac: None,
         }
     }
 
@@ -106,6 +110,7 @@ impl InterfaceConfiguration {
             route_priority: 10,
             ip_configuration: InterfaceIpConfiguration::Router(Default::default()),
             interface_stack: InterfaceStack::Ap,
+            custom_mac: None,
         }
     }
 
@@ -117,6 +122,7 @@ impl InterfaceConfiguration {
             route_priority: 30,
             ip_configuration: InterfaceIpConfiguration::Client(Default::default()),
             interface_stack: InterfaceStack::Ppp,
+            custom_mac: None,
         }
     }
 
@@ -128,6 +134,7 @@ impl InterfaceConfiguration {
             route_priority: 20,
             ip_configuration: InterfaceIpConfiguration::Router(Default::default()),
             interface_stack: InterfaceStack::Ppp,
+            custom_mac: None,
         }
     }
 
@@ -139,6 +146,7 @@ impl InterfaceConfiguration {
             route_priority: 35,
             ip_configuration: InterfaceIpConfiguration::Client(Default::default()),
             interface_stack: InterfaceStack::Slip,
+            custom_mac: None,
         }
     }
 
@@ -150,6 +158,7 @@ impl InterfaceConfiguration {
             route_priority: 25,
             ip_configuration: InterfaceIpConfiguration::Router(Default::default()),
             interface_stack: InterfaceStack::Slip,
+            custom_mac: None,
         }
     }
 }
@@ -199,6 +208,30 @@ impl EspNetif {
         let c_if_key = CString::new(conf.key.as_str()).unwrap();
         let c_if_description = CString::new(conf.description.as_str()).unwrap();
 
+        let initial_mac = if let Some(custom_mac) = conf.custom_mac {
+            custom_mac
+        } else {
+            let mut mac = [0; 6];
+            match conf.interface_stack {
+                InterfaceStack::Sta => esp!(unsafe {
+                    esp_read_mac(mac.as_mut_ptr() as *mut _, esp_mac_type_t_ESP_MAC_WIFI_STA)
+                })?,
+                InterfaceStack::Ap => esp!(unsafe {
+                    esp_read_mac(
+                        mac.as_mut_ptr() as *mut _,
+                        esp_mac_type_t_ESP_MAC_WIFI_SOFTAP,
+                    )
+                })?,
+                InterfaceStack::Eth => esp!(unsafe {
+                    esp_read_mac(mac.as_mut_ptr() as *mut _, esp_mac_type_t_ESP_MAC_ETH)
+                })?,
+                #[cfg(esp_idf_slip_support)]
+                #[cfg(esp_idf_ppp_support)]
+                _ => {}
+            };
+            mac
+        };
+
         let (mut esp_inherent_config, ip_info, dhcps, dns, secondary_dns, hostname) = match conf
             .ip_configuration
         {
@@ -214,7 +247,7 @@ impl EspNetif {
                             esp_netif_flags_ESP_NETIF_FLAG_AUTOUP
                         }
                     },
-                    mac: [0; 6],
+                    mac: initial_mac,
                     ip_info: ptr::null(),
                     get_ip_event: match ip_conf {
                         ipv4::ClientConfiguration::DHCP(_) => {
@@ -269,7 +302,7 @@ impl EspNetif {
                     } else {
                         0
                     }) | esp_netif_flags_ESP_NETIF_FLAG_AUTOUP,
-                    mac: [0; 6],
+                    mac: initial_mac,
                     ip_info: ptr::null(),
                     get_ip_event: 0,
                     lost_ip_event: 0,
@@ -367,6 +400,11 @@ impl EspNetif {
 
         esp!(unsafe { esp_netif_get_mac(self.1, mac.as_mut_ptr() as *mut _) })?;
         Ok(mac)
+    }
+
+    pub fn set_mac(&mut self, mac: &[u8; 6]) -> Result<(), EspError> {
+        esp!(unsafe { esp_netif_set_mac(self.1, mac.clone().as_mut_ptr() as *mut _) })?;
+        Ok(())
     }
 
     pub fn get_dns(&self) -> ipv4::Ipv4Addr {


### PR DESCRIPTION
This PR sets the default mac for any initialized mac (if it can be done reasonably) and allows to set a custom max during creation (or at a later point in time).

That way the `get_mac` method doesn't require an unsafe call to [esp_netif_set_mac](https://esp-rs.github.io/esp-idf-svc/esp_idf_sys/fn.esp_netif_set_mac.html) to initially set the mac address.

This is a breaking change, as it modifies the members of the InterfaceConfiguration struct.

closes #105 