### PR TITLE
Fix: only call esp_wifi_disconnect() when esp_wifi_connect() was called

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -570,14 +570,10 @@ impl EspWifi {
 
             shared.operating = false;
 
-            esp!(unsafe { esp_wifi_disconnect() }).or_else(|err| {
-                if err.code() == esp_idf_sys::ESP_ERR_WIFI_NOT_STARTED as esp_err_t {
-                    Ok(())
-                } else {
-                    Err(err)
-                }
-            })?;
-            info!("Disconnect requested");
+            if let Status(ClientStatus::Started(_), _) = shared.status {
+                esp!(unsafe { esp_wifi_disconnect() })?;
+                info!("Disconnect requested");
+            }
 
             esp!(unsafe { esp_wifi_stop() })?;
             info!("Stop requested");


### PR DESCRIPTION
ESP-IDF seems to assume that you only call esp_wifi_disconnect
when you called esp_wifi_connect first. Otherwise it will
simply return -1, without explaining further why.

The ESP_ERR_WIFI_NOT_STARTED is only returned when esp_wifi_start()
wasn't called. But ClientStatus cannot be Connected if it hasn't.
As such, that check is no longer required.

Fixes #89, and see there for more discussion about this topic.