### PR TITLE
Copy str when reading http headers

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -234,7 +234,7 @@ impl<'a> EspHttpRequestWrite<'a> {
                         // TODO: Replace with a proper conversion from ISO-8859-1 to UTF8
 
                         headers_ptr.as_mut().unwrap().insert(
-                            Uncased::from(from_cstr_ptr(event.header_key)),
+                            Uncased::from(from_cstr_ptr(event.header_key).to_string()),
                             from_cstr_ptr(event.header_value).to_string(),
                         );
                     }


### PR DESCRIPTION
This fixes a crash where a `str` was taken to be `'static` when in reality it was only available for the duration of a callback.