### PR TITLE
Fix time formatting in FirmwareInfo

### DIFF
--- a/src/ota.rs
+++ b/src/ota.rs
@@ -30,7 +30,7 @@ impl From<Newtype<&esp_app_desc_t>> for ota::FirmwareInfo {
 
         write!(
             &mut result.released,
-            "{}{}",
+            "{} {}",
             unsafe { from_cstr_ptr(&app_desc.date as *const _) },
             unsafe { from_cstr_ptr(&app_desc.time as *const _) }
         )


### PR DESCRIPTION
Fix time formatting in FirmwareInfo