### PR TITLE
disambiguate crate `log` and `esp_idf_sys::log`

### DIFF
--- a/src/netif.rs
+++ b/src/netif.rs
@@ -635,7 +635,7 @@ mod status {
 
     use alloc::sync::Arc;
 
-    use log::info;
+    use ::log::info;
 
     use esp_idf_sys::*;
 


### PR DESCRIPTION
```
error[E0659]: `log` is ambiguous
   --> /home/ronen/.cargo/git/checkouts/esp-idf-svc-a28457b0e32c6283/707bd7e/src/netif.rs:638:9
    |
638 |     use log::info;
    |         ^^^ ambiguous name
    |
    = note: ambiguous because of multiple potential import sources
    = note: `log` could refer to a crate passed with `--extern`
    = help: use `::log` to refer to this crate unambiguously
note: `log` could also refer to the struct imported here
   --> /home/ronen/.cargo/git/checkouts/esp-idf-svc-a28457b0e32c6283/707bd7e/src/netif.rs:640:9
    |
640 |     use esp_idf_sys::*;
    |         ^^^^^^^^^^^^^^
    = help: use `self::log` to refer to this struct unambiguously

For more information about this error, try `rustc --explain E0659`.
error: could not compile `esp-idf-svc` due to previous error
```