### PR TITLE
Fix #146 by providing std::ptr::null if payload is empty

### DIFF
--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -459,11 +459,16 @@ impl<S> EspMqttClient<S> {
     ) -> Result<client::MessageId, EspError> {
         let c_topic = CString::new(topic).unwrap();
 
+        let payload_ptr = match payload.len() {
+            0 => core::ptr::null(),
+            _ => payload.as_ptr(),
+        };
+
         Self::check(unsafe {
             esp_mqtt_client_publish(
                 self.raw_client,
                 c_topic.as_ptr(),
-                payload.as_ptr() as _,
+                payload_ptr as _,
                 payload.len() as _,
                 qos as _,
                 retain as _,
@@ -480,11 +485,16 @@ impl<S> EspMqttClient<S> {
     ) -> Result<client::MessageId, EspError> {
         let c_topic = CString::new(topic).unwrap();
 
+        let payload_ptr = match payload.len() {
+            0 => core::ptr::null(),
+            _ => payload.as_ptr(),
+        };
+
         Self::check(unsafe {
             esp_mqtt_client_enqueue(
                 self.raw_client,
                 c_topic.as_ptr(),
-                payload.as_ptr() as _,
+                payload_ptr as _,
                 payload.len() as _,
                 qos as _,
                 retain as _,


### PR DESCRIPTION
this is fixing #146 the issue that a pointer to [] is actually 0x1 (not 0x0).

I fixed not only publish() but also enqueue() as this was also not working (but failed silent for me).

There is a new commit https://github.com/espressif/esp-idf/issues/9719 which fixes the enqueue() function in esp-idf which would cause an actual issue in the rust enqueue() function as well.