### PR TITLE
make `IpEvent` `Send`

### DIFF
--- a/src/netif.rs
+++ b/src/netif.rs
@@ -535,6 +535,8 @@ pub enum IpEvent {
     DhcpIpDeassigned(*mut esp_netif_t),
 }
 
+unsafe impl Send for IpEvent {}
+
 impl IpEvent {
     pub fn is_for(&self, raw_handle: &impl RawHandle<Handle = *mut esp_netif_t>) -> bool {
         self.is_for_handle(raw_handle.handle())
@@ -549,9 +551,9 @@ impl IpEvent {
     pub fn handle(&self) -> Option<*mut esp_netif_t> {
         match self {
             Self::ApStaIpAssigned(_) => None,
-            Self::DhcpIpAssigned(assignment) => Some(assignment.netif_handle as _),
-            Self::DhcpIp6Assigned(assignment) => Some(assignment.netif_handle as _),
-            Self::DhcpIpDeassigned(handle) => Some(*handle as _),
+            Self::DhcpIpAssigned(assignment) => Some(assignment.netif_handle),
+            Self::DhcpIp6Assigned(assignment) => Some(assignment.netif_handle),
+            Self::DhcpIpDeassigned(handle) => Some(*handle),
         }
     }
 }


### PR DESCRIPTION
The `*mut esp_netif_t` makes `IpEvent` not implement `Send`, so it's either `unsafe impl Send for IpEvent {}` as I've done here, or to wrap the pointer in `RawHandleImpl`, and have it implement `RawHandle` just like `EspNetif`, I'm ok with that too. @ivmarkov, what do you think?