### PR TITLE
Make EspOtaUpdate Send

### DIFF
--- a/src/ota.rs
+++ b/src/ota.rs
@@ -374,6 +374,8 @@ impl ota::Ota for EspOta {
     }
 }
 
+unsafe impl Send for EspOtaUpdate {}
+
 impl io::Io for EspOtaUpdate {
     type Error = EspIOError;
 }


### PR DESCRIPTION
This way when using async/await to receive ota data, the future can be `Send`, which some executors expect.