### PR TITLE
Fix new clippy lints, added null-by-default fields in `httpd_ssl_config_t`"

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -158,6 +158,8 @@ impl From<&Configuration> for Newtype<httpd_ssl_config_t> {
             }
         };
         // Default values taken from: https://github.com/espressif/esp-idf/blob/master/components/esp_https_server/include/esp_https_server.h#L114
+
+        #[allow(clippy::needless_update)]
         Self(httpd_ssl_config_t {
             httpd: http_config.0,
             session_tickets: false,
@@ -179,6 +181,7 @@ impl From<&Configuration> for Newtype<httpd_ssl_config_t> {
             #[cfg(not(esp_idf_version_major = "4"))]
             servercert_len: 0,
             user_cb: None,
+            ..Default::default()
         })
     }
 }

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -181,6 +181,7 @@ impl<'a> From<&'a MqttClientConfiguration<'a>> for (esp_mqtt_client_config_t, Ra
     }
 }
 
+#[allow(clippy::needless_update)]
 #[cfg(not(esp_idf_version_major = "4"))]
 impl<'a> From<&'a MqttClientConfiguration<'a>> for (esp_mqtt_client_config_t, RawCstrs) {
     fn from(conf: &'a MqttClientConfiguration<'a>) -> Self {

--- a/src/ota.rs
+++ b/src/ota.rs
@@ -197,9 +197,8 @@ impl EspOta {
     pub fn is_factory_reset_supported(&self) -> Result<bool, EspError> {
         self.check_read()?;
 
-        Ok(self
-            .get_factory_partition()
-            .map(|factory| !factory.is_null())?)
+        self.get_factory_partition()
+            .map(|factory| !factory.is_null())
     }
 
     pub fn factory_reset(&mut self) -> Result<(), EspError> {
@@ -235,9 +234,9 @@ impl EspOta {
 
     pub fn mark_running_slot_invalid_and_reboot(&mut self) -> EspError {
         if let Err(err) = self.check_read() {
-            err.into()
+            err
         } else if let Err(err) = esp!(unsafe { esp_ota_mark_app_invalid_rollback_and_reboot() }) {
-            err.into()
+            err
         } else {
             unreachable!()
         }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -270,7 +270,9 @@ mod isr {
 
     pub type EspISRTimerService = super::EspTimerService<ISR>;
 
-    impl super::EspTimerService<ISR> {
+    impl EspISRTimerService {
+        /// # Safety
+        /// TODO
         pub unsafe fn new() -> Result<Self, EspError> {
             Ok(Self(ISR))
         }


### PR DESCRIPTION
- new fields added in `esp-idf/master`, all defaulting to `NULL`
- fix new clippy lints
