### PR TITLE
Get rid of `static mut`, force WS handler to be `Send + Sync`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cstr_core = "0.2"
 uncased = "0.9.7"
 anyhow = { version = "1", default-features = false, optional = true } # Only used by the deprecated httpd module
 embedded-svc = { version = "0.23", default-features = false, git = "https://github.com/esp-rs/embedded-svc" }
-esp-idf-sys = { version = "0.31.10", default-features = false, features = ["native"] }
+esp-idf-sys = { version = "0.31.11", default-features = false, features = ["native"] }
 esp-idf-hal = { version = "0.39", default-features = false, features = ["esp-idf-sys"], git = "https://github.com/esp-rs/esp-idf-hal" }
 embassy-sync = { version = "0.1", optional = true }
 embassy-time = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }


### PR DESCRIPTION
I'm pretty sure using a `static mut` to store types that don't implement `Send` may be unsound.
`EspHttpServer::stop` can be called from any thread, and if we pass a closure that isn't `Send`, and then call stop from another thread, it would be unsound.
Not sure about `httpd` internals, does it promise to only call the handler from the same thread? If not it also has to be `Sync` (which also is a requirement by  the borrow checker anyway.