### PR TITLE
Add rustflags for building with ESP IDF 5

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build.'cfg(esp_idf_version_major = "5")']
+rustflags = ["--cfg", "espidf_time64"]


### PR DESCRIPTION
* Without them, building this crate failed with the error message
    ```
    $ export ESP_IDF_VERSION=release/v5.0
    $ rm -rf .embuild
    $ cargo clean
    $ export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo +nightly build --features experimental --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
    [...]
       Compiling embedded-svc v0.23.1
    error[E0308]: mismatched types
      --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/esp-idf-sys-0.31.11/src/lib.rs:36:62
       |
    36 | const ESP_IDF_TIME64_CHECK: ::std::os::espidf::raw::time_t = 0 as crate::time_t;
       |                                                              ^^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`

    error[E0308]: mismatched types
      --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/esp-idf-sys-0.31.11/src/lib.rs:38:51
       |
    38 | const ESP_IDF_TIME64_CHECK_LIBC: ::libc::time_t = 0 as crate::time_t;
       |                                                   ^^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`
    ```
* It was not obvious to me how to get this sorted out at a first glance
* Thank you very much @Vollbrecht for your help!
* What about using these flags by default (for development builds) for this repository?