### PR TITLE
Ensure HTTP server responds to JSON requests in JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ esp-idf-sys = { version = "0.32", default-features = false, features = ["native"
 esp-idf-hal = { version = "0.40", default-features = false, features = ["esp-idf-sys"] }
 embassy-sync = { version = "0.1", optional = true }
 embassy-time = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }
+serde_json = "1.0.87"
 
 [build-dependencies]
 embuild = "0.31"

--- a/src/ota.rs
+++ b/src/ota.rs
@@ -3,8 +3,8 @@ use core::fmt::Write;
 use core::mem;
 use core::ptr;
 
-use ::log::*;
 use embedded_svc::ota::Slot;
+use log::*;
 
 use embedded_svc::io;
 use embedded_svc::ota;
@@ -282,7 +282,7 @@ impl EspOta {
 
         Ok(if err == ESP_ERR_NOT_FOUND {
             ota::SlotState::Unknown
-        } else if err == ESP_ERR_NOT_SUPPORTED as _ {
+        } else if err == ESP_ERR_NOT_SUPPORTED {
             ota::SlotState::Factory
         } else {
             esp!(err)?;


### PR DESCRIPTION
It's a bit awkward handling errors client side as `text/html` when working in the context of machine-to-machine comms via JSON.