### PR TITLE
Fix for `ESP-Now` with `esp-idf` master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ log = { version = "0.4", default-features = false }
 uncased = "0.9.7"
 anyhow = { version = "1", default-features = false, optional = true } # Only used by the deprecated httpd module
 embedded-svc = { version = "0.24", default-features = false }
-esp-idf-sys = { version = "0.32", default-features = false, features = ["native"] }
+esp-idf-sys = { version = "0.32.1", default-features = false, features = ["native"] }
 esp-idf-hal = { version = "0.40", default-features = false, features = ["esp-idf-sys"] }
 embassy-sync = { version = "0.1", optional = true }
 embassy-time = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }

--- a/src/espnow.rs
+++ b/src/espnow.rs
@@ -162,7 +162,15 @@ impl EspNow {
         }
     }
 
-    extern "C" fn recv_callback(mac_addr: *const u8, data: *const u8, data_len: core::ffi::c_int) {
+    extern "C" fn recv_callback(
+        #[cfg(any(esp_idf_version_major = "4", esp_idf_version_minor = "0"))] mac_addr: *const u8,
+        #[cfg(not(any(esp_idf_version_major = "4", esp_idf_version_minor = "0")))]
+        esp_now_info: *const esp_now_recv_info_t,
+        data: *const u8,
+        data_len: core::ffi::c_int,
+    ) {
+        #[cfg(not(any(esp_idf_version_major = "4", esp_idf_version_minor = "0")))]
+        let mac_addr = unsafe { *esp_now_info }.src_addr.cast_const();
         let c_mac = unsafe { core::slice::from_raw_parts(mac_addr, 6usize) };
         let c_data = unsafe { core::slice::from_raw_parts(data, data_len as usize) };
 

--- a/src/espnow.rs
+++ b/src/espnow.rs
@@ -44,7 +44,7 @@ impl EspNow {
         let mut taken = TAKEN.lock();
 
         if *taken {
-            esp!(ESP_ERR_INVALID_STATE)?;
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_STATE>());
         }
 
         // disable modem sleep, otherwise messages queue up and we're not able

--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -315,7 +315,7 @@ impl EventLoopHandle<System> {
         let mut taken = TAKEN.lock();
 
         if *taken {
-            esp!(ESP_ERR_INVALID_STATE)?;
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_STATE>());
         }
 
         esp!(unsafe { esp_event_loop_create_default() })?;
@@ -469,9 +469,7 @@ where
         if result == ESP_ERR_TIMEOUT {
             Ok(false)
         } else {
-            esp!(result)?;
-
-            Ok(true)
+            esp_result!(result, true)
         }
     }
 
@@ -544,7 +542,7 @@ where
             let result = {
                 panic!("Trying to post from an ISR handler. Enable `CONFIG_ESP_EVENT_POST_FROM_ISR` in `sdkconfig.defaults`");
 
-                Err(EspError::from(ESP_FAIL).unwrap())
+                Err(EspError::from_infallible::<ESP_FAIL>())
             };
 
             result

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -953,7 +953,7 @@ pub mod ws {
 
                     Ok(EspHttpWsDetachedSender::new(*sd, fd, closed.clone()))
                 }
-                Self::Closed(_) => Err(EspError::from(ESP_FAIL).unwrap()),
+                Self::Closed(_) => Err(EspError::from_infallible::<ESP_FAIL>()),
             }
         }
 
@@ -968,17 +968,13 @@ pub mod ws {
 
                     Ok(())
                 }
-                _ => {
-                    esp!(ESP_FAIL)?;
-
-                    Ok(())
-                }
+                _ => Err(EspError::from_infallible::<ESP_FAIL>()),
             }
         }
 
         pub fn recv(&mut self, frame_data_buf: &mut [u8]) -> Result<(FrameType, usize), EspError> {
             match self {
-                Self::New(_, _) => Err(EspError::from(ESP_FAIL).unwrap()),
+                Self::New(_, _) => Err(EspError::from_infallible::<ESP_FAIL>()),
                 Self::Receiving(_, raw_req) => {
                     let mut raw_frame: httpd_ws_frame_t = Default::default();
 
@@ -1145,7 +1141,7 @@ pub mod ws {
 
                 esp!((*guard).unwrap())?;
             } else {
-                esp!(ESP_FAIL)?;
+                return Err(EspError::from_infallible::<ESP_FAIL>());
             }
 
             Ok(())

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -136,7 +136,7 @@ impl EspMdns {
         let mut taken = TAKEN.lock();
 
         if *taken {
-            esp!(ESP_ERR_INVALID_STATE)?;
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_STATE>());
         }
 
         info!("Initializing MDNS");

--- a/src/napt.rs
+++ b/src/napt.rs
@@ -30,7 +30,7 @@ impl EspNapt {
         let mut taken = TAKEN.lock();
 
         if *taken {
-            esp!(ESP_ERR_INVALID_STATE as i32)?;
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_STATE>());
         }
 
         *taken = true;

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -472,7 +472,7 @@ impl EspNetif {
         if let Ok(hostname) = CString::new(hostname) {
             esp!(unsafe { esp_netif_set_hostname(self.0, hostname.as_ptr() as *const _) })?;
         } else {
-            esp!(ESP_ERR_INVALID_ARG)?;
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>());
         }
 
         Ok(())

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -170,7 +170,7 @@ impl EspNotify {
         } else {
             unsafe { Weak::from_raw(registry_weak_ptr) };
 
-            Err(EspError::from(ESP_FAIL).unwrap())
+            Err(EspError::from_infallible::<ESP_FAIL>())
         }
     }
 

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -35,7 +35,7 @@ impl NvsDefault {
         let mut taken = DEFAULT_TAKEN.lock();
 
         if *taken {
-            esp!(ESP_ERR_INVALID_STATE)?;
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_STATE>());
         }
 
         let default_nvs = Self::init()?;
@@ -90,7 +90,7 @@ impl NvsCustom {
         let c_partition = CString::new(partition).unwrap();
 
         if registrations.contains(c_partition.as_ref()) {
-            return Err(EspError::from(ESP_ERR_INVALID_STATE).unwrap());
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_STATE>());
         }
 
         unsafe {
@@ -304,7 +304,7 @@ impl<T: NvsPartitionId> EspNvs<T> {
 
                 if buf.len() < len as _ {
                     // Buffer not large enough
-                    return Err(EspError::from(ESP_ERR_NVS_INVALID_LENGTH).unwrap());
+                    return Err(EspError::from_infallible::<ESP_ERR_NVS_INVALID_LENGTH>());
                 }
 
                 u64value >>= 8;

--- a/src/ota.rs
+++ b/src/ota.rs
@@ -96,7 +96,7 @@ impl ota::FirmwareInfoLoader for EspFirmwareInfoLoader {
 
             Ok(Newtype(app_desc).into())
         } else {
-            Err(EspError::from(ESP_ERR_INVALID_SIZE as _).unwrap().into())
+            Err(EspError::from_infallible::<ESP_ERR_INVALID_SIZE>().into())
         }
     }
 }
@@ -149,7 +149,7 @@ impl EspOtaUpdate {
         if !self.update_partition.is_null() {
             Ok(())
         } else {
-            Err(EspError::from(ESP_FAIL).unwrap())
+            Err(EspError::from_infallible::<ESP_FAIL>())
         }
     }
 }
@@ -162,7 +162,7 @@ impl EspOta {
         let mut taken = TAKEN.lock();
 
         if *taken {
-            esp!(ESP_ERR_INVALID_STATE)?;
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_STATE>());
         }
 
         *taken = true;
@@ -254,7 +254,7 @@ impl EspOta {
         };
 
         if partition_iterator.is_null() {
-            esp!(ESP_ERR_NOT_SUPPORTED)?;
+            return Err(EspError::from_infallible::<ESP_ERR_NOT_SUPPORTED>());
         }
 
         let partition = unsafe { esp_partition_get(partition_iterator) };
@@ -322,7 +322,7 @@ impl EspOta {
         if self.0.update_partition.is_null() {
             Ok(())
         } else {
-            Err(EspError::from(ESP_FAIL).unwrap())
+            Err(EspError::from_infallible::<ESP_FAIL>())
         }
     }
 }

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -93,7 +93,7 @@ impl EspPing {
         })?;
 
         if handle.is_null() {
-            return Err(EspError::from(ESP_ERR_INVALID_ARG as _).unwrap());
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>());
         }
 
         info!("Ping session established, got handle {:?}", handle);

--- a/src/private/net.rs
+++ b/src/private/net.rs
@@ -66,7 +66,7 @@ impl TryFrom<Newtype<esp_ip4_addr_t>> for Mask {
         let ip: ipv4::Ipv4Addr = esp_ip.into();
 
         ip.try_into()
-            .map_err(|_| EspError::from(ESP_ERR_INVALID_ARG).unwrap())
+            .map_err(|_| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
     }
 }
 
@@ -85,7 +85,7 @@ impl TryFrom<Newtype<ip4_addr_t>> for Mask {
         let ip: ipv4::Ipv4Addr = esp_ip.into();
 
         ip.try_into()
-            .map_err(|_| EspError::from(ESP_ERR_INVALID_ARG).unwrap())
+            .map_err(|_| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
     }
 }
 

--- a/src/sntp.rs
+++ b/src/sntp.rs
@@ -129,7 +129,7 @@ impl EspSntp {
         let mut taken = TAKEN.lock();
 
         if *taken {
-            esp!(ESP_ERR_INVALID_STATE)?;
+            return Err(EspError::from_infallible::<ESP_ERR_INVALID_STATE>());
         }
 
         let sntp = Self::init(conf)?;

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -103,7 +103,7 @@ impl WebSocketClosingReason {
             1009 => Ok(Self::MessageTooBig),
             1010 => Ok(Self::ExtensionNotReturned),
             1011 => Ok(Self::UnexpectedCondition),
-            _ => Err(EspError::from(ESP_ERR_NOT_SUPPORTED).unwrap().into()),
+            _ => Err(EspError::from_infallible::<ESP_ERR_NOT_SUPPORTED>().into()),
         }
     }
 }
@@ -123,7 +123,7 @@ impl<'a> WebSocketEventType<'a> {
         #[allow(non_upper_case_globals)]
         match event_id {
             esp_websocket_event_id_t_WEBSOCKET_EVENT_ERROR => {
-                Err(EspError::from(ESP_FAIL).unwrap().into())
+                Err(EspError::from_infallible::<ESP_FAIL>().into())
             }
             esp_websocket_event_id_t_WEBSOCKET_EVENT_CONNECTED => Ok(Self::Connected),
             esp_websocket_event_id_t_WEBSOCKET_EVENT_DISCONNECTED => Ok(Self::Disconnected),
@@ -137,7 +137,7 @@ impl<'a> WebSocketEventType<'a> {
                         );
                         core::str::from_utf8(slice)
                     }
-                    .map_err(|_| EspError::from(ESP_FAIL).unwrap().into())
+                    .map_err(|_| EspError::from_infallible::<ESP_FAIL>().into())
                     .map(Self::Text),
                     // Binary frame
                     2 => Ok(Self::Binary(unsafe {
@@ -155,11 +155,11 @@ impl<'a> WebSocketEventType<'a> {
                     } else {
                         None
                     })),
-                    _ => Err(EspError::from(ESP_ERR_NOT_FOUND).unwrap().into()),
+                    _ => Err(EspError::from_infallible::<ESP_ERR_NOT_FOUND>().into()),
                 }
             }
             esp_websocket_event_id_t_WEBSOCKET_EVENT_CLOSED => Ok(Self::Closed),
-            _ => Err(EspError::from(ESP_ERR_INVALID_ARG).unwrap().into()),
+            _ => Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>().into()),
         }
     }
 }
@@ -244,7 +244,7 @@ impl<'a> TryFrom<&'a EspWebSocketClientConfig<'a>> for (esp_websocket_client_con
         #[cfg(esp_idf_version = "4.4")]
         if let Some(if_name) = conf.if_name {
             if !(if_name.len() == 6 && if_name.is_ascii()) {
-                return Err(EspError::from(ESP_ERR_INVALID_ARG).unwrap().into());
+                return Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>().into());
             }
             let mut s: [ffi::c_char; 6] = [ffi::c_char::default(); 6];
             for (i, c) in if_name.chars().enumerate() {
@@ -430,7 +430,7 @@ impl EspWebSocketClient {
         let handle = unsafe { esp_websocket_client_init(&conf) };
 
         if handle.is_null() {
-            esp!(ESP_FAIL)?;
+            return Err(EspError::from_infallible::<ESP_FAIL>());
         }
 
         let client = Self {
@@ -491,11 +491,10 @@ impl EspWebSocketClient {
     }
 
     fn check(result: ffi::c_int) -> Result<usize, EspError> {
-        if result < 0 {
-            esp!(result)?;
+        match EspError::from(result) {
+            Some(err) if result < 0 => Err(err),
+            _ => Ok(result as _),
         }
-
-        Ok(result as _)
     }
 
     fn send_data(&mut self, frame_type: FrameType, frame_data: &[u8]) -> Result<usize, EspError> {

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -430,7 +430,7 @@ impl EspWebSocketClient {
         let handle = unsafe { esp_websocket_client_init(&conf) };
 
         if handle.is_null() {
-            return Err(EspError::from_infallible::<ESP_FAIL>());
+            return Err(EspError::from_infallible::<ESP_FAIL>().into());
         }
 
         let client = Self {


### PR DESCRIPTION
- fix `ESP NOW` for `esp-idf` `master` and `v5.1+`
- use `EspError::from_infallible`
