### PR TITLE
Wifi driver config only if changed

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1134,6 +1134,7 @@ impl<'d> Drop for EspWifi<'d> {
     }
 }
 
+#[cfg(esp_idf_comp_esp_netif_enabled)]
 unsafe impl<'d> Send for EspWifi<'d> {}
 
 #[cfg(esp_idf_comp_esp_netif_enabled)]

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -370,8 +370,6 @@ impl<'d> WifiDriver<'d> {
     pub fn stop(&mut self) -> Result<(), EspError> {
         info!("Stop requested");
 
-        let _ = esp!(unsafe { esp_wifi_disconnect() });
-
         esp!(unsafe { esp_wifi_stop() })?;
 
         info!("Stopping");
@@ -701,7 +699,8 @@ impl<'d> WifiDriver<'d> {
     fn do_scan(&mut self) -> Result<usize, EspError> {
         info!("About to scan for access points");
 
-        self.stop()?;
+        let _ = self.disconnect();
+        let _ = self.stop();
 
         unsafe {
             esp!(esp_wifi_set_mode(wifi_mode_t_WIFI_MODE_STA))?;

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -578,7 +578,7 @@ impl<'d> WifiDriver<'d> {
                 }
                 info!("Wifi mode AP set");
 
-                self.set_ap_conf(ap_conf)?;
+                self.set_ap_conf_if_changed(ap_conf)?;
             }
             Configuration::Client(client_conf) => {
                 unsafe {
@@ -586,7 +586,7 @@ impl<'d> WifiDriver<'d> {
                 }
                 info!("Wifi mode STA set");
 
-                self.set_sta_conf(client_conf)?;
+                self.set_sta_conf_if_changed(client_conf)?;
             }
             Configuration::Mixed(client_conf, ap_conf) => {
                 unsafe {
@@ -594,8 +594,8 @@ impl<'d> WifiDriver<'d> {
                 }
                 info!("Wifi mode APSTA set");
 
-                self.set_sta_conf(client_conf)?;
-                self.set_ap_conf(ap_conf)?;
+                self.set_sta_conf_if_changed(client_conf)?;
+                self.set_ap_conf_if_changed(ap_conf)?;
             }
         }
 
@@ -742,6 +742,15 @@ impl<'d> WifiDriver<'d> {
         Ok(result)
     }
 
+    fn set_sta_conf_if_changed(&mut self, conf: &ClientConfiguration) -> Result<(), EspError> {
+        let curr_config = self.get_sta_conf()?;
+        if !conf.eq(&curr_config) {
+            self.set_sta_conf(conf)?;
+        }
+
+        Ok(())
+    }
+
     fn set_sta_conf(&mut self, conf: &ClientConfiguration) -> Result<(), EspError> {
         info!("Setting STA configuration: {:?}", conf);
 
@@ -765,6 +774,15 @@ impl<'d> WifiDriver<'d> {
         info!("Providing AP configuration: {:?}", &result);
 
         Ok(result)
+    }
+
+    fn set_ap_conf_if_changed(&mut self, conf: &AccessPointConfiguration) -> Result<(), EspError> {
+        let curr_config = self.get_ap_conf()?;
+        if !conf.eq(&curr_config) {
+            self.set_ap_conf(conf)?;
+        }
+
+        Ok(())
     }
 
     fn set_ap_conf(&mut self, conf: &AccessPointConfiguration) -> Result<(), EspError> {


### PR DESCRIPTION
My scenario looks like the following:

```rust
let wifi = WifiDriver::new(...);
wifi.set_configuration(AP mode);
wifi.start();

let listener = TcpListener::new(AP IP Address);
task::spawn(move async { loop { listener.next().await } };

// scan for aps
wifi.set_configuration(AP + STA mode); // "upgrade" ap config to mixed config => old ap config + new sta config

wifi.start_scan(ScanConfig::default(), true);
let result = wifi.get_scan_result();

wifi.set_configuration(AP);
```

The scenario will fail at listening to the `TcpListener` while upgrading wifi config (ap -> mixed). This is because the ap config is set again while setting a mixed config.

The changes in the pull request will set the wifi interface config only if it changed.

In my opinion, this would not change the current behavior. I cannot think of a reason why the wifi interface should be reconfigured if the config has not changed.

Another possibility to make this work would be to set the wifi config to mixed at start. But this would start the sta interface from the beginning as well when it's not needed.