### PR TITLE
Improve crate docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,7 @@ embassy-time = { version = "0.1", optional = true, features = ["tick-hz-1_000_00
 [build-dependencies]
 embuild = "0.31"
 anyhow = "1"
+
+[[example]]
+name = "http_request"
+required-features = ["experimental"]

--- a/examples/http_request.rs
+++ b/examples/http_request.rs
@@ -1,0 +1,108 @@
+//! Simple example. Won't run in practice without a WiFi connection, but should
+//! typecheck.
+//!
+//! Note: Requires `experimental` cargo feature to be enabled
+
+use embedded_svc::{
+    http::{client::Client as HttpClient, Method, Status},
+    io::Write,
+    utils::io,
+};
+use esp_idf_svc::http::client::{Configuration as HttpConfiguration, EspHttpConnection};
+
+fn main() -> anyhow::Result<()> {
+    // Create HTTP(S) client
+    let mut client = HttpClient::wrap(EspHttpConnection::new(&HttpConfiguration {
+        crt_bundle_attach: Some(esp_idf_sys::esp_crt_bundle_attach), // Needed for HTTPS support
+        ..Default::default()
+    })?);
+
+    // GET
+    get_request(&mut client)?;
+
+    // POST
+    post_request(&mut client)?;
+
+    Ok(())
+}
+
+/// Send a HTTP GET request.
+fn get_request(client: &mut HttpClient<EspHttpConnection>) -> anyhow::Result<()> {
+    // Prepare headers and URL
+    let headers = [("accept", "text/plain"), ("connection", "close")];
+    let url = "http://ifconfig.net/";
+
+    // Send request
+    //
+    // Note: If you don't want to pass in any headers, you can also use `client.get(url, headers)`.
+    let request = client.request(Method::Get, &url, &headers)?;
+    println!("-> GET {}", url);
+    let mut response = request.submit()?;
+
+    // Process response
+    let status = response.status();
+    println!("<- {}", status);
+    println!();
+    let (_headers, mut body) = response.split();
+    let mut buf = [0u8; 1024];
+    let bytes_read = io::try_read_full(&mut body, &mut buf).map_err(|e| e.0)?;
+    println!("Read {} bytes", bytes_read);
+    match std::str::from_utf8(&buf[0..bytes_read]) {
+        Ok(body_string) => println!(
+            "Response body (truncated to {} bytes): {:?}",
+            buf.len(),
+            body_string
+        ),
+        Err(e) => eprintln!("Error decoding response body: {}", e),
+    };
+
+    // Drain the remaining response bytes
+    while body.read(&mut buf)? > 0 {}
+
+    Ok(())
+}
+
+/// Send a HTTP POST request.
+fn post_request(client: &mut HttpClient<EspHttpConnection>) -> anyhow::Result<()> {
+    // Prepare payload
+    let payload = b"Hello world!";
+
+    // Prepare headers and URL
+    let content_length_header = format!("{}", payload.len());
+    let headers = [
+        ("accept", "text/plain"),
+        ("content-type", "text/plain"),
+        ("connection", "close"),
+        ("content-length", &*content_length_header),
+    ];
+    let url = "http://example.org/";
+
+    // Send request
+    let mut request = client.post(&url, &headers)?;
+    request.write_all(payload)?;
+    request.flush()?;
+    println!("-> POST {}", url);
+    let mut response = request.submit()?;
+
+    // Process response
+    let status = response.status();
+    println!("<- {}", status);
+    println!();
+    let (_headers, mut body) = response.split();
+    let mut buf = [0u8; 1024];
+    let bytes_read = io::try_read_full(&mut body, &mut buf).map_err(|e| e.0)?;
+    println!("Read {} bytes", bytes_read);
+    match std::str::from_utf8(&buf[0..bytes_read]) {
+        Ok(body_string) => println!(
+            "Response body (truncated to {} bytes): {:?}",
+            buf.len(),
+            body_string
+        ),
+        Err(e) => eprintln!("Error decoding response body: {}", e),
+    };
+
+    // Drain the remaining response bytes
+    while body.read(&mut buf)? > 0 {}
+
+    Ok(())
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+//! Error types
+
 use core::fmt::{self, Display, Formatter};
 
 use embedded_svc::io::{Error, ErrorKind};

--- a/src/espnow.rs
+++ b/src/espnow.rs
@@ -1,3 +1,11 @@
+//! ESP-NOW
+//!
+//! ESP-NOW is a kind of connectionless Wi-Fi communication protocol that is
+//! defined by Espressif. In ESP-NOW, application data is encapsulated in a
+//! vendor-specific action frame and then transmitted from one Wi-Fi device to
+//! another without connection. CTR with CBC-MAC Protocol(CCMP) is used to
+//! protect the action frame for security. ESP-NOW is widely used in smart
+//! light, remote controlling, sensor, etc.
 use ::log::info;
 
 use alloc::boxed::Box;

--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -1,3 +1,5 @@
+//! Event loop library
+
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::result::Result;

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,3 +1,4 @@
+//! Wrapper around ESP-IDF raw handles
 pub trait RawHandle {
     type Handle;
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,6 @@
+//! Experimental HTTP server and client
+//!
+//! Note: This module requires the `experimental` cargo feature to be enabled.
 #[cfg(all(feature = "alloc", esp_idf_comp_esp_http_client_enabled))]
 pub mod client;
 #[cfg(all(feature = "alloc", esp_idf_comp_esp_http_server_enabled))]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,3 +1,6 @@
+//! HTTP client
+//!
+//! This provides a set of APIs for making HTTP(S) requests.
 use core::cell::UnsafeCell;
 
 extern crate alloc;

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,6 +1,10 @@
 //! HTTP client
 //!
 //! This provides a set of APIs for making HTTP(S) requests.
+//!
+//! You can find a usage example at
+//! [`examples/http_request.rs`](https://github.com/esp-rs/esp-idf-svc/blob/master/examples/http_request.rs).
+
 use core::cell::UnsafeCell;
 
 extern crate alloc;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,3 +1,4 @@
+//! HTTP server
 use core::cell::UnsafeCell;
 use core::fmt::{Debug, Display};
 use core::sync::atomic::{AtomicBool, Ordering};

--- a/src/httpd.rs
+++ b/src/httpd.rs
@@ -1,3 +1,7 @@
+//! HTTP server
+//!
+//! The HTTP Server component provides an ability for running a lightweight web
+//! server on ESP32.
 #![allow(deprecated)]
 
 use core::{ffi::*, marker::PhantomData, ptr};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,16 @@
+//! This crate contains wrappers which are mostly implementations of the
+//! abstractions defined in the [embedded-svc](../embedded_svc/index.html)
+//! project. It has features such as wifi, networking, httpd, logging.
+//!
+//! ## Features
+//!
+//! This crates specifies a few cargo features, including:
+//!
+//! - `std`: Enable the use of std. Enabled by default.
+//! - `experimental`: Enable the use of experimental features, including a HTTP
+//!   client.
+//! - `embassy-time-driver`
+//! - `embassy-time-isr-queue`
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(cfg_version)]
 #![cfg_attr(

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,3 +1,4 @@
+//! Logging
 use core::fmt::Write;
 
 use ::log::{Level, LevelFilter, Metadata, Record};

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -1,3 +1,5 @@
+//! mDNS Service
+
 use core::time::Duration;
 
 extern crate alloc;

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -1,1 +1,5 @@
+//! MQTT protocol
+//!
+//! MQTT is a lightweight publish/subscribe messaging protocol.
+
 pub mod client;

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -1,3 +1,4 @@
+//! MQTT protocol client
 use core::convert::TryInto;
 use core::ffi::c_void;
 use core::fmt::{self, Debug};

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -1,3 +1,13 @@
+//! Network abstraction
+//!
+//! The purpose of ESP-NETIF library is twofold:
+//!
+//! - It provides an abstraction layer for the application on top of the TCP/IP
+//!   stack. This will allow applications to choose between IP stacks in the
+//!   future.
+//! - The APIs it provides are thread safe, even if the underlying TCP/IP
+//!   stack APIs are not.
+
 use core::convert::TryInto;
 use core::{ffi, ptr};
 
@@ -18,12 +28,17 @@ pub use status::*;
 #[cfg_attr(feature = "std", derive(Hash))]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub enum NetifStack {
+    /// Station mode (WiFi client)
     Sta,
+    /// Access point mode (WiFi router)
     Ap,
+    /// Ethernet
     Eth,
     #[cfg(esp_idf_ppp_support)]
+    /// Point-to-Point Protocol (PPP)
     Ppp,
     #[cfg(esp_idf_slip_support)]
+    /// Serial Line Internet Protocol (SLIP)
     Slip,
 }
 

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -1,3 +1,4 @@
+//! Non-Volatile Storage (NVS)
 use core::ptr;
 
 extern crate alloc;

--- a/src/ota.rs
+++ b/src/ota.rs
@@ -1,3 +1,9 @@
+//! Over The Air Updates (OTA)
+//!
+//! The OTA update mechanism allows a device to update itself based on data
+//! received while the normal firmware is running (for example, over Wi-Fi or
+//! Bluetooth.)
+
 use core::cmp::min;
 use core::fmt::Write;
 use core::mem;

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,3 +1,4 @@
+//! Send ICMP echo requests (Ping)
 use core::{ffi, mem, ptr, time::Duration};
 
 use ::log::*;

--- a/src/sntp.rs
+++ b/src/sntp.rs
@@ -1,3 +1,5 @@
+//! SNTP Time Synchronization
+
 use core::cmp::min;
 
 use ::log::*;

--- a/src/systime.rs
+++ b/src/systime.rs
@@ -1,12 +1,15 @@
+//! System time
 use core::time::Duration;
 
 use embedded_svc::sys_time::SystemTime;
 
 use esp_idf_sys::*;
 
+/// Client for the ESP system time
 pub struct EspSystemTime;
 
 impl EspSystemTime {
+    /// Return the current system time
     pub fn now(&self) -> Duration {
         let mut tv_now: timeval = Default::default();
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,3 +1,14 @@
+//! High resolution hardware timer based task scheduling
+//!
+//! Although FreeRTOS provides software timers, these timers have a few
+//! limitations:
+//!
+//! - Maximum resolution is equal to RTOS tick period
+//! - Timer callbacks are dispatched from a low-priority task
+//!
+//! EspTimer is a set of APIs that provides one-shot and periodic timers,
+//! microsecond time resolution, and 52-bit range.
+
 use core::result::Result;
 use core::time::Duration;
 use core::{ffi, ptr};

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,3 +1,4 @@
+//! TLS-related helper types
 use core::ffi::{c_char, CStr};
 use core::fmt::Debug;
 

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1,3 +1,4 @@
+//! WiFi support
 use core::marker::PhantomData;
 use core::time::Duration;
 use core::{cmp, ffi};

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,3 +1,5 @@
+//! WebSocket protocol
+
 #[cfg(all(
     feature = "alloc",
     feature = "experimental",

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -1,3 +1,5 @@
+//! WebSocket client
+
 use core::convert::{TryFrom, TryInto};
 use core::{ffi, time};
 


### PR DESCRIPTION
The crate documentation is quite _very_ sparse. It was often hard for me to piece together how to use a certain API.

Here's a first start:

- Add basic crate docs, especially for top-level modules
- Add usage example for HTTP client

Before:

![screenshot-20221231-163953](https://user-images.githubusercontent.com/105168/210147758-f14e45ee-9ea2-4db2-af79-45074e5f57b1.png)

After:

![screenshot-20221231-164003](https://user-images.githubusercontent.com/105168/210147790-22e2870b-d523-4127-b4c4-400e026c492c.png)

Note: I put the usage example in an example file instead of using rustdoc, because Rust currently does not support cross-compiled doctests.