### PR TITLE
added ESP IDF esp_ota_get_last_invalid_partition() Rust wrapper

### DIFF
--- a/src/ota.rs
+++ b/src/ota.rs
@@ -194,6 +194,18 @@ impl EspOta {
         })
     }
 
+    pub fn get_last_invalid_slot(&self) -> Result<Option<Slot>, EspError> {
+        self.check_read()?;
+
+        let partition = unsafe { esp_ota_get_last_invalid_partition().as_ref() };
+
+        if partition.is_some() {
+            Ok(Some(self.get_slot(partition.unwrap()).unwrap()))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn is_factory_reset_supported(&self) -> Result<bool, EspError> {
         self.check_read()?;
 


### PR DESCRIPTION
The Rust wrapper for ```esp_ota_get_last_invalid_partition()``` is currently missing in ```esp-idf-svc```. This PR adds this function. This function is useful in the context of the two already implemented functions ```mark_running_slot_valid()``` and ```mark_running_slot_invalid_and_reboot()``` which are used to indicate that an app flashed through OTA is valid or not valid. The proposed new function ```get_last_invalid_slot()``` can be used during the OTA update process to check if the version of the new downloaded image is same same as the one which is stored in a slot which is marked as invalid.

The PR has been tested with a slot marked as invalid and with no invalid slots. 