### PR TITLE
Investigate problem after #200

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ anyhow = "1"
 [[example]]
 name = "http_request"
 required-features = ["experimental"]
+


### PR DESCRIPTION
Seems to be some sporadic CI failures after #200 got merged.

Error seems to be [this](https://github.com/esp-rs/esp-idf-svc/actions/runs/3843969715/jobs/6546681147#step:25:58):


##### Install Rust for Xtensa
```
Run esp-rs/xtensa-toolchain@main
[...]
Run curl -L https://github.com/esp-rs/embuild/releases/latest/download/ldproxy-x86_64-unknown-linux-gnu.zip 
[...]
Run curl -L https://github.com/esp-rs/espup/releases/latest/download/espup-x86_64-unknown-linux-gnu  -o 
[...]
Run bash /home/runner/work/_actions/esp-rs/xtensa-toolchain/main/install.sh all latest
  bash /home/runner/work/_actions/esp-rs/xtensa-toolchain/main/install.sh all latest
  [[ "true" = true ]] && rustup default esp || true
  [[ "true" = true ]] && rustup override unset || true
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    rust_toolchain: nightly
jq: error (at <stdin>:4): Cannot index string with string "prerelease"
ERROR: version number is not correctly formatted: 
Error: Process completed with exit code 1.
```