### PR TITLE
X509 should have same lifetime as MqttClientConfiguration

### DIFF
--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -75,10 +75,10 @@ pub struct MqttClientConfiguration<'a> {
     #[cfg(not(esp_idf_version = "4.3"))]
     pub crt_bundle_attach: Option<unsafe extern "C" fn(conf: *mut c_void) -> esp_err_t>,
 
-    pub server_certificate: Option<X509<'static>>,
+    pub server_certificate: Option<X509<'a>>,
 
-    pub client_certificate: Option<X509<'static>>,
-    pub private_key: Option<X509<'static>>,
+    pub client_certificate: Option<X509<'a>>,
+    pub private_key: Option<X509<'a>>,
     pub private_key_password: Option<&'a str>,
     // TODO: Future
     // pub psk_hint_key: KeyHint,


### PR DESCRIPTION
certificates do not need to live for `'static` lifetime. As other fields like `private_key_password` live for lifetime of our config, same should be with `X509`.

`'static` lifetime gets in our way when we have to parse the certs at runtime, e.g. from a JSON file. Changing it to have same lifetime as `MqttClientConfiguration` should make it much easier for users.