### PR TITLE
Increase rate limit by adding secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   rust_toolchain: nightly
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   compile:


### PR DESCRIPTION
With Xtensa toolchain release 1.5, defining GITHUB_TOKEN will increase our rate limit per hour.