### PR TITLE
make set_target_level() available and fix should_log() to use target not hard coded `rust-logging`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ esp-idf-sys = { version = "0.32.1", default-features = false, features = ["nativ
 esp-idf-hal = { version = "0.40", default-features = false, features = ["esp-idf-sys"] }
 embassy-sync = { version = "0.1", optional = true }
 embassy-time = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }
-once_cell = "1.17.0"
 
 [build-dependencies]
 embuild = "0.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ esp-idf-sys = { version = "0.32.1", default-features = false, features = ["nativ
 esp-idf-hal = { version = "0.40", default-features = false, features = ["esp-idf-sys"] }
 embassy-sync = { version = "0.1", optional = true }
 embassy-time = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }
+once_cell = "1.17.0"
 
 [build-dependencies]
 embuild = "0.31"

--- a/src/log.rs
+++ b/src/log.rs
@@ -99,7 +99,7 @@ impl EspLogger {
         LevelFilter::from(Newtype(CONFIG_LOG_MAXIMUM_LEVEL))
     }
 
-    pub fn set_target_level(&self, target: impl AsRef<str>, level_filter: LevelFilter) {
+    pub fn set_target_level(target: impl AsRef<str>, level_filter: LevelFilter) {
         let ctarget = CString::new(target.as_ref()).unwrap();
 
         unsafe {
@@ -139,10 +139,29 @@ impl EspLogger {
 
     #[cfg(not(all(esp_idf_version_major = "4", esp_idf_version_minor = "3")))]
     fn should_log(record: &Record) -> bool {
+        use alloc::collections::BTreeMap;
+        use crate::private::mutex::Mutex;
+
+        // esp-idf `function esp_log_level_get` builds a cache using the address
+        // of the target and not doing a string compare.  This means we need to
+        // build a cache of our own mapping the string value to a consistant 
+        // c-string value.
+        static TARGET_CACHE: Mutex<BTreeMap<String, CString>> = Mutex::new(BTreeMap::new());
         let level = Newtype::<esp_log_level_t>::from(record.level()).0;
-        let max_level = unsafe {
-            esp_log_level_get(b"rust-logging\0" as *const u8 as *const _) // TODO: use record target?
+        let mut cache = TARGET_CACHE.lock();
+        let ctarget = match cache.get(record.target()) {
+            Some(value) => value,
+            None => {
+                // println!("EspLogger::should_log: add to cache target={}", record.target());
+                let value = CString::new(record.target()).unwrap();
+                cache.insert(record.target().to_string(), value);
+                cache.get(record.target()) .unwrap()
+            }
         };
+        let max_level = unsafe {
+            esp_log_level_get(ctarget.as_c_str().as_ptr())
+        };
+        // println!("EspLogger::should_log: target={} max_level={}", record.target(), max_level);
         level <= max_level
     }
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -142,11 +142,11 @@ impl EspLogger {
         use crate::private::mutex::{Mutex, RawMutex};
         use alloc::collections::BTreeMap;
 
-        // esp-idf `function esp_log_level_get` builds a cache using the address
+        // esp-idf function `esp_log_level_get` builds a cache using the address
         // of the target and not doing a string compare.  This means we need to
         // build a cache of our own mapping the string value to a consistant
         // c-string value.
-        static TARGET_CACHE: Mutex<BTreeMap<String, CString>> =
+        static TARGET_CACHE: Mutex<BTreeMap<alloc::string::String, CString>> =
             Mutex::wrap(RawMutex::new(), BTreeMap::new());
         let level = Newtype::<esp_log_level_t>::from(record.level()).0;
         let mut cache = TARGET_CACHE.lock();

--- a/src/log.rs
+++ b/src/log.rs
@@ -141,12 +141,13 @@ impl EspLogger {
     fn should_log(record: &Record) -> bool {
         use crate::private::mutex::Mutex;
         use alloc::collections::BTreeMap;
+        use once_cell::sync::Lazy;
 
         // esp-idf `function esp_log_level_get` builds a cache using the address
         // of the target and not doing a string compare.  This means we need to
         // build a cache of our own mapping the string value to a consistant
         // c-string value.
-        static TARGET_CACHE: Mutex<BTreeMap<String, CString>> = Mutex::new(BTreeMap::new());
+        static TARGET_CACHE: Lazy<Mutex<BTreeMap<String, CString>>> = Lazy::new(|| Mutex::new(BTreeMap::new()));
         let level = Newtype::<esp_log_level_t>::from(record.level()).0;
         let mut cache = TARGET_CACHE.lock();
         let ctarget = match cache.get(record.target()) {

--- a/src/log.rs
+++ b/src/log.rs
@@ -139,12 +139,12 @@ impl EspLogger {
 
     #[cfg(not(all(esp_idf_version_major = "4", esp_idf_version_minor = "3")))]
     fn should_log(record: &Record) -> bool {
-        use alloc::collections::BTreeMap;
         use crate::private::mutex::Mutex;
+        use alloc::collections::BTreeMap;
 
         // esp-idf `function esp_log_level_get` builds a cache using the address
         // of the target and not doing a string compare.  This means we need to
-        // build a cache of our own mapping the string value to a consistant 
+        // build a cache of our own mapping the string value to a consistant
         // c-string value.
         static TARGET_CACHE: Mutex<BTreeMap<String, CString>> = Mutex::new(BTreeMap::new());
         let level = Newtype::<esp_log_level_t>::from(record.level()).0;
@@ -155,12 +155,10 @@ impl EspLogger {
                 // println!("EspLogger::should_log: add to cache target={}", record.target());
                 let value = CString::new(record.target()).unwrap();
                 cache.insert(record.target().to_string(), value);
-                cache.get(record.target()) .unwrap()
+                cache.get(record.target()).unwrap()
             }
         };
-        let max_level = unsafe {
-            esp_log_level_get(ctarget.as_c_str().as_ptr())
-        };
+        let max_level = unsafe { esp_log_level_get(ctarget.as_c_str().as_ptr()) };
         // println!("EspLogger::should_log: target={} max_level={}", record.target(), max_level);
         level <= max_level
     }


### PR DESCRIPTION
- log::EspLogger::set_target_level make function not method
    Made this a function so that it can be called via log::EspLogger::set_target_level()
- log::EspLogger::should_log implement cache for CStrings
    so it turns out that  esp-idf `function esp_log_level_get` builds a cache using the address
    of the target and not doing a string compare.  This means we need to
    build a cache of our own mapping the target string value to a consistant 
    CString value.
