### PR TITLE
Fix panic when using esp_dpp due to non-exhaustive WifiEvent match

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1272,6 +1272,8 @@ impl EspTypedEventDeserializer<WifiEvent> for WifiEvent {
             WifiEvent::ActionTxStatus
         } else if event_id == wifi_event_t_WIFI_EVENT_STA_BEACON_TIMEOUT {
             WifiEvent::StaBeaconTimeout
+        } else if event_id == wifi_event_t_WIFI_EVENT_ROC_DONE {
+            WifiEvent::RocDone
         } else {
             panic!("Unknown event ID: {}", event_id);
         };


### PR DESCRIPTION
WIFI_EVENT_ROC_DONE specifically was missing and is used by esp_dpp. Causes a panic when calling esp_supp_dpp_start_listen();