### PR TITLE
Hide wifi password from info prints

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1348,7 +1348,7 @@ impl WifiWait {
     }
 }
 
-fn format_config_without_password(config: &Configuration) -> String {
+fn format_config_without_password(config: &Configuration) -> alloc::string::String {
     match config {
         Configuration::None => format!("{config:?}"),
         Configuration::Client(client) => format_client_config_without_password(client),
@@ -1362,6 +1362,6 @@ fn format_config_without_password(config: &Configuration) -> String {
     }
 }
 
-fn format_client_config_without_password(config: &ClientConfiguration) -> String {
+fn format_client_config_without_password(config: &ClientConfiguration) -> alloc::string::String {
     format!("Client(ClientConfiguration {{ ssid: {:?}, bssid: {:?}, auth_method: {:?}, channel: {:?} }})", config.ssid, config.bssid, config.auth_method, config.channel)
 }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1278,6 +1278,8 @@ impl EspTypedEventDeserializer<WifiEvent> for WifiEvent {
             WifiEvent::ActionTxStatus
         } else if event_id == wifi_event_t_WIFI_EVENT_STA_BEACON_TIMEOUT {
             WifiEvent::StaBeaconTimeout
+        } else if event_id == wifi_event_t_WIFI_EVENT_ROC_DONE {
+            WifiEvent::RocDone
         } else {
             panic!("Unknown event ID: {}", event_id);
         };


### PR DESCRIPTION
Printing the Wi-Fi password in plain-text over UART is a security risk.
We didn't want to prevent others from printing it if they really want to (hence we didn't override the Debug implementation), so we found this to be the simplest solution