### PR TITLE
Added websocket ping/pong event types

### DIFF
--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -119,7 +119,7 @@ pub enum WebSocketEventType<'a> {
     Text(&'a str),
     Binary(&'a [u8]),
     Ping,
-    Pong
+    Pong,
 }
 
 impl<'a> WebSocketEventType<'a> {

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -118,6 +118,8 @@ pub enum WebSocketEventType<'a> {
     Closed,
     Text(&'a str),
     Binary(&'a [u8]),
+    Ping,
+    Pong
 }
 
 impl<'a> WebSocketEventType<'a> {
@@ -157,6 +159,8 @@ impl<'a> WebSocketEventType<'a> {
                     } else {
                         None
                     })),
+                    9 => Ok(Self::Ping),
+                    10 => Ok(Self::Pong),
                     _ => Err(EspError::from_infallible::<ESP_ERR_NOT_FOUND>().into()),
                 }
             }


### PR DESCRIPTION
When receiving ping and pong messages on a websocket connection there would previously be an ```EspError``` returned to the user. This change adds the ping and pong events to the ```WebSocketEventType``` and returns them to the user.