### PR TITLE
Added async Wifi implementation with stubs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ embassy-time-isr-queue = [
     "embassy-time",
     "esp-idf-hal/embassy-sync",
 ]
+async = ["embedded-svc/nightly", "embedded-svc/experimental"]
 
 [dependencies]
 heapless = { version = "0.7", default-features = false }
@@ -60,3 +61,7 @@ anyhow = "1"
 [[example]]
 name = "http_request"
 required-features = ["experimental"]
+
+[[example]]
+name = "wifi_async"
+required-features = ["async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ nightly = ["embedded-svc/nightly"]
 experimental = ["embedded-svc/experimental"]
 embassy-time-driver = ["embassy-time"]
 embassy-time-isr-queue = ["embassy-sync", "embassy-time", "esp-idf-hal/embassy-sync"]
-async = ["embedded-svc/nightly", "embedded-svc/experimental", "nightly"]
 
 [dependencies]
 heapless = { version = "0.7", default-features = false }
@@ -47,4 +46,4 @@ required-features = ["experimental"]
 
 [[example]]
 name = "wifi_async"
-required-features = ["async"]
+required-features = ["nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,24 +16,13 @@ rust-version = "1.61"
 [features]
 default = ["std"]
 
-std = [
-    "alloc",
-    "anyhow/std",
-    "log/std",
-    "esp-idf-sys/std",
-    "esp-idf-hal/std",
-    "embedded-svc/std",
-]
+std = ["alloc", "anyhow/std", "log/std", "esp-idf-sys/std", "esp-idf-hal/std", "embedded-svc/std"]
 alloc = ["anyhow", "esp-idf-hal/alloc", "embedded-svc/alloc"]
 nightly = ["embedded-svc/nightly"]
 experimental = ["embedded-svc/experimental"]
 embassy-time-driver = ["embassy-time"]
-embassy-time-isr-queue = [
-    "embassy-sync",
-    "embassy-time",
-    "esp-idf-hal/embassy-sync",
-]
-async = ["embedded-svc/nightly", "embedded-svc/experimental"]
+embassy-time-isr-queue = ["embassy-sync", "embassy-time", "esp-idf-hal/embassy-sync"]
+async = ["embedded-svc/nightly", "embedded-svc/experimental", "nightly"]
 
 [dependencies]
 heapless = { version = "0.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,16 +31,10 @@ log = { version = "0.4", default-features = false }
 uncased = "0.9.7"
 anyhow = { version = "1", default-features = false, optional = true } # Only used by the deprecated httpd module
 embedded-svc = { git = "https://github.com/esp-rs/embedded-svc.git", branch = "master" }
-esp-idf-sys = { version = "0.32.1", default-features = false, features = [
-    "native",
-] }
-esp-idf-hal = { version = "0.40", default-features = false, features = [
-    "esp-idf-sys",
-] }
+esp-idf-sys = { version = "0.32.1", default-features = false, features = ["native"] }
+esp-idf-hal = { version = "0.40", default-features = false, features = ["esp-idf-sys"] }
 embassy-sync = { version = "0.1", optional = true }
-embassy-time = { version = "0.1", optional = true, features = [
-    "tick-hz-1_000_000",
-] }
+embassy-time = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }
 futures = "0.3.27"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,23 @@ rust-version = "1.61"
 [features]
 default = ["std"]
 
-std = ["alloc", "anyhow/std", "log/std", "esp-idf-sys/std", "esp-idf-hal/std", "embedded-svc/std"]
+std = [
+    "alloc",
+    "anyhow/std",
+    "log/std",
+    "esp-idf-sys/std",
+    "esp-idf-hal/std",
+    "embedded-svc/std",
+]
 alloc = ["anyhow", "esp-idf-hal/alloc", "embedded-svc/alloc"]
 nightly = ["embedded-svc/nightly"]
 experimental = ["embedded-svc/experimental"]
 embassy-time-driver = ["embassy-time"]
-embassy-time-isr-queue = ["embassy-sync", "embassy-time", "esp-idf-hal/embassy-sync"]
+embassy-time-isr-queue = [
+    "embassy-sync",
+    "embassy-time",
+    "esp-idf-hal/embassy-sync",
+]
 
 [dependencies]
 heapless = { version = "0.7", default-features = false }
@@ -29,11 +40,18 @@ enumset = { version = "1", default-features = false }
 log = { version = "0.4", default-features = false }
 uncased = "0.9.7"
 anyhow = { version = "1", default-features = false, optional = true } # Only used by the deprecated httpd module
-embedded-svc = { version = "0.24", default-features = false }
-esp-idf-sys = { version = "0.32.1", default-features = false, features = ["native"] }
-esp-idf-hal = { version = "0.40", default-features = false, features = ["esp-idf-sys"] }
+embedded-svc = { git = "https://github.com/esp-rs/embedded-svc.git", branch = "master" }
+esp-idf-sys = { version = "0.32.1", default-features = false, features = [
+    "native",
+] }
+esp-idf-hal = { version = "0.40", default-features = false, features = [
+    "esp-idf-sys",
+] }
 embassy-sync = { version = "0.1", optional = true }
-embassy-time = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }
+embassy-time = { version = "0.1", optional = true, features = [
+    "tick-hz-1_000_000",
+] }
+futures = "0.3.27"
 
 [build-dependencies]
 embuild = "0.31"

--- a/examples/wifi_async.rs
+++ b/examples/wifi_async.rs
@@ -1,0 +1,41 @@
+//! Example of using async wifi.
+//!
+//! Add your own ssid and password
+//!
+//! Note: Requires `nightly` and `experimental` cargo feature to be enabled
+
+extern crate esp_idf_svc;
+use embedded_svc::wifi::asynch::Wifi;
+use embedded_svc::wifi::{AuthMethod, ClientConfiguration, Configuration};
+use esp_idf_hal::prelude::Peripherals;
+use esp_idf_svc::wifi::EspAsyncWifiDriver;
+use esp_idf_svc::{eventloop::EspSystemEventLoop, nvs::EspDefaultNvsPartition};
+use futures::executor::block_on;
+
+const SSID: &'static str = "<Your SSID here>";
+const PASSWORD: &'static str = "<Your password here>";
+
+fn main() -> anyhow::Result<()> {
+    let peripherals = Peripherals::take().unwrap();
+    let sys_loop = EspSystemEventLoop::take().unwrap();
+    let nvs = EspDefaultNvsPartition::take().unwrap();
+
+    let mut wifi = EspAsyncWifiDriver::new(peripherals.modem, sys_loop, Some(nvs))?;
+
+    block_on(do_wifi(&mut wifi))?;
+
+    Ok(())
+}
+
+async fn do_wifi<'a>(wifi: &mut EspAsyncWifiDriver<'a>) -> anyhow::Result<()> {
+    let wifi_configuration: Configuration = Configuration::Client(ClientConfiguration {
+        ssid: SSID.into(),
+        bssid: None,
+        auth_method: AuthMethod::WPA2Personal,
+        password: PASSWORD.into(),
+        channel: None,
+    });
+
+    wifi.set_configuration(&wifi_configuration).await?;
+    wifi.connect().await.map_err(|e| e.into())
+}

--- a/examples/wifi_async.rs
+++ b/examples/wifi_async.rs
@@ -8,7 +8,7 @@ extern crate esp_idf_svc;
 use embedded_svc::wifi::asynch::Wifi;
 use embedded_svc::wifi::{AuthMethod, ClientConfiguration, Configuration};
 use esp_idf_hal::prelude::Peripherals;
-use esp_idf_svc::wifi::EspAsyncWifiDriver;
+use esp_idf_svc::wifi::AsyncWifiDriver;
 use esp_idf_svc::{eventloop::EspSystemEventLoop, nvs::EspDefaultNvsPartition};
 use futures::executor::block_on;
 
@@ -19,15 +19,15 @@ fn main() -> anyhow::Result<()> {
     let peripherals = Peripherals::take().unwrap();
     let sys_loop = EspSystemEventLoop::take().unwrap();
     let nvs = EspDefaultNvsPartition::take().unwrap();
-
-    let mut wifi = EspAsyncWifiDriver::new(peripherals.modem, sys_loop, Some(nvs))?;
+    let mut base_driver = WifiDriver::new(peripherals.modem, sys_loop, Some(nvs))?;
+    let mut wifi = AsyncWifiDriver::new(base_driver);
 
     block_on(do_wifi(&mut wifi))?;
 
     Ok(())
 }
 
-async fn do_wifi<'a>(wifi: &mut EspAsyncWifiDriver<'a>) -> anyhow::Result<()> {
+async fn do_wifi<'a>(wifi: &mut AsyncWifiDriver<'a>) -> anyhow::Result<()> {
     let wifi_configuration: Configuration = Configuration::Client(ClientConfiguration {
         ssid: SSID.into(),
         bssid: None,

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1515,7 +1515,7 @@ where
         self.base_driver.borrow_mut().scan_n()
     }
 
-    pub async fn scan(&mut self) -> Result<Vec<AccessPointInfo>, EspError> {
+    pub async fn scan(&mut self) -> Result<alloc::vec::Vec<AccessPointInfo>, EspError> {
         let base: &mut WifiDriver<'d> = self.base_driver.borrow_mut();
         base.scan()
     }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -11,7 +11,7 @@ use ::log::*;
 
 use enumset::*;
 
-#[cfg(all(feature = "nightly", feature = "experimental"))]
+#[cfg(feature = "async")]
 use embedded_svc::wifi::asynch;
 
 use embedded_svc::wifi::*;
@@ -1446,12 +1446,12 @@ impl WifiWait {
     }
 }
 
-#[cfg(all(feature = "nightly", feature = "experimental"))]
+#[cfg(all(feature = "async"))]
 pub struct EspAsyncWifiDriver<'d> {
     sync: WifiDriver<'d>,
 }
 
-#[cfg(all(feature = "nightly", feature = "experimental"))]
+#[cfg(all(feature = "async"))]
 impl<'d> EspAsyncWifiDriver<'d> {
     #[cfg(all(feature = "alloc", esp_idf_comp_nvs_flash_enabled))]
     pub fn new<M: WifiModemPeripheral>(
@@ -1465,7 +1465,7 @@ impl<'d> EspAsyncWifiDriver<'d> {
     }
 }
 
-#[cfg(all(feature = "nightly", feature = "experimental"))]
+#[cfg(all(feature = "async"))]
 impl<'d> asynch::Wifi for EspAsyncWifiDriver<'d> {
     type Error = EspError;
 

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -18,10 +18,8 @@ use esp_idf_hal::peripheral::Peripheral;
 
 use esp_idf_sys::*;
 
-#[cfg(feature = "async")]
+#[cfg(feature = "nightly")]
 use core::borrow::BorrowMut;
-#[cfg(feature = "async")]
-use embedded_svc::wifi::asynch;
 
 use crate::eventloop::EspEventLoop;
 use crate::eventloop::{
@@ -332,30 +330,6 @@ pub struct WifiDriver<'d> {
     _p: PhantomData<&'d mut ()>,
 }
 
-#[cfg(feature = "async")]
-type GetCapabilitiesFuture = futures::future::Ready<Result<EnumSet<Capability>, EspError>>;
-#[cfg(feature = "async")]
-type GetConfigurationFuture = futures::future::Ready<Result<Configuration, EspError>>;
-#[cfg(feature = "async")]
-type SetConfigurationFuture = futures::future::Ready<Result<(), EspError>>;
-#[cfg(feature = "async")]
-type StartFuture = futures::future::Ready<Result<(), EspError>>;
-#[cfg(feature = "async")]
-type StopFuture = futures::future::Ready<Result<(), EspError>>;
-#[cfg(feature = "async")]
-type ConnectFuture = futures::future::Ready<Result<(), EspError>>;
-#[cfg(feature = "async")]
-type DisconnectFuture = futures::future::Ready<Result<(), EspError>>;
-#[cfg(feature = "async")]
-type IsStartedFuture = futures::future::Ready<Result<bool, EspError>>;
-#[cfg(feature = "async")]
-type IsConnectedFuture = futures::future::Ready<Result<bool, EspError>>;
-#[cfg(feature = "async")]
-type ScanNFuture<const N: usize> =
-    futures::future::Ready<Result<(heapless::Vec<AccessPointInfo, N>, usize), EspError>>;
-#[cfg(feature = "async")]
-type ScanFuture = futures::future::Ready<Result<alloc::vec::Vec<AccessPointInfo>, EspError>>;
-
 impl<'d> WifiDriver<'d> {
     #[cfg(all(feature = "alloc", esp_idf_comp_nvs_flash_enabled))]
     pub fn new<M: WifiModemPeripheral>(
@@ -468,11 +442,6 @@ impl<'d> WifiDriver<'d> {
         Ok(caps)
     }
 
-    #[cfg(feature = "async")]
-    pub fn get_capabilities_async(&self) -> GetCapabilitiesFuture {
-        futures::future::ready(self.get_capabilities())
-    }
-
     pub fn start(&mut self) -> Result<(), EspError> {
         info!("Start requested");
 
@@ -481,11 +450,6 @@ impl<'d> WifiDriver<'d> {
         info!("Starting");
 
         Ok(())
-    }
-
-    #[cfg(feature = "async")]
-    pub fn start_async(&mut self) -> StartFuture {
-        futures::future::ready(self.start())
     }
 
     pub fn stop(&mut self) -> Result<(), EspError> {
@@ -498,11 +462,6 @@ impl<'d> WifiDriver<'d> {
         Ok(())
     }
 
-    #[cfg(feature = "async")]
-    pub fn stop_async(&mut self) -> StopFuture {
-        futures::future::ready(self.stop())
-    }
-
     pub fn connect(&mut self) -> Result<(), EspError> {
         info!("Connect requested");
 
@@ -513,11 +472,6 @@ impl<'d> WifiDriver<'d> {
         Ok(())
     }
 
-    #[cfg(feature = "async")]
-    pub fn connect_async(&mut self) -> ConnectFuture {
-        futures::future::ready(self.connect())
-    }
-
     pub fn disconnect(&mut self) -> Result<(), EspError> {
         info!("Disconnect requested");
 
@@ -526,11 +480,6 @@ impl<'d> WifiDriver<'d> {
         info!("Disconnecting");
 
         Ok(())
-    }
-
-    #[cfg(feature = "async")]
-    pub fn disconnect_async(&mut self) -> DisconnectFuture {
-        futures::future::ready(self.disconnect())
     }
 
     pub fn is_ap_enabled(&self) -> Result<bool, EspError> {
@@ -577,11 +526,6 @@ impl<'d> WifiDriver<'d> {
         }
     }
 
-    #[cfg(feature = "async")]
-    pub fn is_started_async(&self) -> IsStartedFuture {
-        futures::future::ready(self.is_started())
-    }
-
     pub fn is_connected(&self) -> Result<bool, EspError> {
         let ap_enabled = self.is_ap_enabled()?;
         let sta_enabled = self.is_sta_enabled()?;
@@ -594,11 +538,6 @@ impl<'d> WifiDriver<'d> {
             Ok((!ap_enabled || guard.1 == WifiEvent::ApStarted)
                 && (!sta_enabled || guard.0 == WifiEvent::StaConnected))
         }
-    }
-
-    #[cfg(feature = "async")]
-    pub fn is_connected_async(&self) -> IsConnectedFuture {
-        futures::future::ready(self.is_connected())
     }
 
     #[allow(non_upper_case_globals)]
@@ -621,11 +560,6 @@ impl<'d> WifiDriver<'d> {
         info!("Configuration gotten: {:?}", &conf);
 
         Ok(conf)
-    }
-
-    #[cfg(feature = "async")]
-    pub fn get_configuration_async(&self) -> GetConfigurationFuture {
-        futures::future::ready(self.get_configuration())
     }
 
     pub fn set_configuration(&mut self, conf: &Configuration) -> Result<(), EspError> {
@@ -670,11 +604,6 @@ impl<'d> WifiDriver<'d> {
         Ok(())
     }
 
-    #[cfg(feature = "async")]
-    pub fn set_configuration_async(&mut self, conf: &Configuration) -> SetConfigurationFuture {
-        futures::future::ready(self.set_configuration(conf))
-    }
-
     /// Scan for nearby, visible access points.
     ///
     /// It scans for all available access points nearby, but returns only the first `N` access points found.
@@ -707,21 +636,11 @@ impl<'d> WifiDriver<'d> {
     /// dynamically.
     ///
     /// For more details see [`WifiDriver::scan_n()`].
-    #[cfg(feature = "async")]
-    pub fn scan_n_async<const N: usize>(&mut self) -> ScanNFuture<N> {
-        futures::future::ready(self.scan_n())
-    }
-
     // For backwards compatibility
     #[cfg(feature = "alloc")]
     pub fn scan(&mut self) -> Result<alloc::vec::Vec<AccessPointInfo>, EspError> {
         self.start_scan(&Default::default(), true)?;
         self.get_scan_result()
-    }
-
-    #[cfg(feature = "async")]
-    pub fn scan_async(&mut self) -> ScanFuture {
-        futures::future::ready(self.scan())
     }
 
     /// Start scanning for nearby, visible access points.
@@ -1527,7 +1446,7 @@ impl WifiWait {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "nightly")]
 pub struct AsyncWifiDriver<'d, T>
 where
     T: BorrowMut<WifiDriver<'d>>,
@@ -1536,7 +1455,7 @@ where
     _p: PhantomData<WifiDriver<'d>>,
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "nightly")]
 impl<'d, T> AsyncWifiDriver<'d, T>
 where
     T: BorrowMut<WifiDriver<'d>>,
@@ -1548,68 +1467,122 @@ where
             _p: PhantomData,
         })
     }
+
+    pub fn get_capabilities(&self) -> Result<EnumSet<Capability>, EspError> {
+        self.base_driver.borrow().get_capabilities()
+    }
+
+    pub fn get_configuration(&self) -> Result<Configuration, EspError> {
+        self.base_driver.borrow().get_configuration()
+    }
+
+    pub fn set_configuration(&mut self, conf: &Configuration) -> Result<(), EspError> {
+        self.base_driver.borrow_mut().set_configuration(conf)
+    }
+
+    pub fn is_started(&self) -> Result<bool, EspError> {
+        self.base_driver.borrow().is_started()
+    }
+
+    pub fn is_connected(&self) -> Result<bool, EspError> {
+        self.base_driver.borrow().is_connected()
+    }
+
+    pub async fn start(&mut self) -> Result<(), EspError> {
+        self.base_driver.borrow_mut().start()
+        // TODO: wait until start is complete
+    }
+
+    pub async fn stop(&mut self) -> Result<(), EspError> {
+        self.base_driver.borrow_mut().stop()
+        // TODO: wait until stop is complete?
+    }
+
+    pub async fn connect(&mut self) -> Result<(), EspError> {
+        self.base_driver.borrow_mut().connect()
+        // TODO: wait until connect is complete
+    }
+
+    pub async fn disconnect(&mut self) -> Result<(), EspError> {
+        self.base_driver.borrow_mut().disconnect()
+        // TODO: wait until stop is complete
+    }
+
+    pub async fn scan_n<const N: usize>(
+        &mut self,
+    ) -> Result<(heapless::Vec<AccessPointInfo, N>, usize), EspError> {
+        // TODO: rewrite to do async waiting here while scanning
+        // Also, it would be nice to have an API that returned entries as they were discovered
+        self.base_driver.borrow_mut().scan_n()
+    }
+
+    pub async fn scan(&mut self) -> Result<Vec<AccessPointInfo>, EspError> {
+        let base: &mut WifiDriver<'d> = self.base_driver.borrow_mut();
+        base.scan()
+    }
 }
 
-#[cfg(all(feature = "async"))]
+#[cfg(all(feature = "nighty", feature = "experimental"))]
 impl<'d, T> asynch::Wifi for AsyncWifiDriver<'d, T>
 where
     T: BorrowMut<WifiDriver<'d>>,
 {
     type Error = EspError;
 
-    type GetCapabilitiesFuture<'a> = GetCapabilitiesFuture where Self: 'a;
-    type GetConfigurationFuture<'a> = GetConfigurationFuture where Self: 'a;
-    type SetConfigurationFuture<'a> = SetConfigurationFuture where Self: 'a;
-    type StartFuture<'a> = StartFuture where Self: 'a;
-    type StopFuture<'a> = StopFuture where Self: 'a;
-    type ConnectFuture<'a> = ConnectFuture where Self: 'a;
-    type DisconnectFuture<'a> = DisconnectFuture where Self: 'a;
-    type IsStartedFuture<'a> = IsStartedFuture where Self: 'a;
-    type IsConnectedFuture<'a> = IsConnectedFuture where Self: 'a;
-    type ScanNFuture<'a, const N: usize> = ScanNFuture<N> where Self: 'a;
-    type ScanFuture<'a> = ScanFuture where Self: 'a;
+    type GetCapabilitiesFuture<'a> = futures::future::Ready<Result<EnumSet<Capability>, EspError>> where Self: 'a;
+    type GetConfigurationFuture<'a> = futures::future::Ready<Result<Configuration, EspError>> where Self: 'a;
+    type SetConfigurationFuture<'a> = futures::future::Ready<Result<(), EspError>> where Self: 'a;
+    type StartFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<(), EspError>> + 'a>> where Self: 'a;
+    type StopFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<(), EspError>> + 'a>> where Self: 'a;
+    type ConnectFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<(), EspError>> + 'a>> where Self: 'a;
+    type DisconnectFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<(), EspError>> + 'a>> where Self: 'a;
+    type IsStartedFuture<'a> = futures::future::Ready<Result<bool, EspError>> where Self: 'a;
+    type IsConnectedFuture<'a> = futures::future::Ready<Result<bool, EspError>> where Self: 'a;
+    type ScanNFuture<'a, const N: usize> = Pin<Box<dyn futures::future::Future<Output = Result<(heapless::Vec<AccessPointInfo, N>, usize), EspError>> + 'a>> where Self: 'a;
+    type ScanFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<alloc::vec::Vec<AccessPointInfo>, EspError>> + 'a>> where Self: 'a;
 
     fn get_capabilities(&self) -> Self::GetCapabilitiesFuture<'_> {
-        self.base_driver.borrow().get_capabilities_async()
+        futures::future::ready(self.get_capabilities())
     }
 
     fn get_configuration(&self) -> Self::GetConfigurationFuture<'_> {
-        self.base_driver.borrow().get_configuration_async()
+        futures::future::ready(self.get_configuration())
     }
 
     fn set_configuration(&mut self, conf: &Configuration) -> Self::SetConfigurationFuture<'_> {
-        self.base_driver.borrow_mut().set_configuration_async(conf)
+        futures::future::ready(self.set_configuration(conf))
     }
 
     fn start(&mut self) -> Self::StartFuture<'_> {
-        self.base_driver.borrow_mut().start_async()
+        // let a = self.start();
+        Box::pin(self.start())
     }
 
     fn stop(&mut self) -> Self::StopFuture<'_> {
-        self.base_driver.borrow_mut().stop_async()
+        Box::pin(self.stop())
     }
 
     fn connect(&mut self) -> Self::ConnectFuture<'_> {
-        self.base_driver.borrow_mut().connect_async()
+        Box::pin(self.connect())
     }
 
     fn disconnect(&mut self) -> Self::DisconnectFuture<'_> {
-        self.base_driver.borrow_mut().disconnect_async()
+        Box::pin(self.disconnect())
     }
 
     fn is_started(&self) -> Self::IsStartedFuture<'_> {
-        self.base_driver.borrow().is_started_async()
+        futures::future::ready(self.is_started())
     }
 
     fn is_connected(&self) -> Self::IsConnectedFuture<'_> {
-        self.base_driver.borrow().is_connected_async()
+        futures::future::ready(self.is_connected())
     }
 
     fn scan_n<const N: usize>(&mut self) -> Self::ScanNFuture<'_, N> {
-        self.base_driver.borrow_mut().scan_n_async()
+        Box::pin(self.scan_n())
     }
 
     fn scan(&mut self) -> Self::ScanFuture<'_> {
-        self.base_driver.borrow_mut().scan_async()
+        Box::pin(self.scan())
     }
 }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -11,15 +11,17 @@ use ::log::*;
 
 use enumset::*;
 
-#[cfg(feature = "async")]
-use embedded_svc::wifi::asynch;
-
 use embedded_svc::wifi::*;
 
 use esp_idf_hal::modem::WifiModemPeripheral;
 use esp_idf_hal::peripheral::Peripheral;
 
 use esp_idf_sys::*;
+
+#[cfg(feature = "async")]
+use core::borrow::BorrowMut;
+#[cfg(feature = "async")]
+use embedded_svc::wifi::asynch;
 
 use crate::eventloop::EspEventLoop;
 use crate::eventloop::{
@@ -330,6 +332,30 @@ pub struct WifiDriver<'d> {
     _p: PhantomData<&'d mut ()>,
 }
 
+#[cfg(feature = "async")]
+type GetCapabilitiesFuture = futures::future::Ready<Result<EnumSet<Capability>, EspError>>;
+#[cfg(feature = "async")]
+type GetConfigurationFuture = futures::future::Ready<Result<Configuration, EspError>>;
+#[cfg(feature = "async")]
+type SetConfigurationFuture = futures::future::Ready<Result<(), EspError>>;
+#[cfg(feature = "async")]
+type StartFuture = futures::future::Ready<Result<(), EspError>>;
+#[cfg(feature = "async")]
+type StopFuture = futures::future::Ready<Result<(), EspError>>;
+#[cfg(feature = "async")]
+type ConnectFuture = futures::future::Ready<Result<(), EspError>>;
+#[cfg(feature = "async")]
+type DisconnectFuture = futures::future::Ready<Result<(), EspError>>;
+#[cfg(feature = "async")]
+type IsStartedFuture = futures::future::Ready<Result<bool, EspError>>;
+#[cfg(feature = "async")]
+type IsConnectedFuture = futures::future::Ready<Result<bool, EspError>>;
+#[cfg(feature = "async")]
+type ScanNFuture<const N: usize> =
+    futures::future::Ready<Result<(heapless::Vec<AccessPointInfo, N>, usize), EspError>>;
+#[cfg(feature = "async")]
+type ScanFuture = futures::future::Ready<Result<alloc::vec::Vec<AccessPointInfo>, EspError>>;
+
 impl<'d> WifiDriver<'d> {
     #[cfg(all(feature = "alloc", esp_idf_comp_nvs_flash_enabled))]
     pub fn new<M: WifiModemPeripheral>(
@@ -442,6 +468,11 @@ impl<'d> WifiDriver<'d> {
         Ok(caps)
     }
 
+    #[cfg(feature = "async")]
+    pub fn get_capabilities_async(&self) -> GetCapabilitiesFuture {
+        futures::future::ready(self.get_capabilities())
+    }
+
     pub fn start(&mut self) -> Result<(), EspError> {
         info!("Start requested");
 
@@ -450,6 +481,11 @@ impl<'d> WifiDriver<'d> {
         info!("Starting");
 
         Ok(())
+    }
+
+    #[cfg(feature = "async")]
+    pub fn start_async(&mut self) -> StartFuture {
+        futures::future::ready(self.start())
     }
 
     pub fn stop(&mut self) -> Result<(), EspError> {
@@ -462,6 +498,11 @@ impl<'d> WifiDriver<'d> {
         Ok(())
     }
 
+    #[cfg(feature = "async")]
+    pub fn stop_async(&mut self) -> StopFuture {
+        futures::future::ready(self.stop())
+    }
+
     pub fn connect(&mut self) -> Result<(), EspError> {
         info!("Connect requested");
 
@@ -472,6 +513,11 @@ impl<'d> WifiDriver<'d> {
         Ok(())
     }
 
+    #[cfg(feature = "async")]
+    pub fn connect_async(&mut self) -> ConnectFuture {
+        futures::future::ready(self.connect())
+    }
+
     pub fn disconnect(&mut self) -> Result<(), EspError> {
         info!("Disconnect requested");
 
@@ -480,6 +526,11 @@ impl<'d> WifiDriver<'d> {
         info!("Disconnecting");
 
         Ok(())
+    }
+
+    #[cfg(feature = "async")]
+    pub fn disconnect_async(&mut self) -> DisconnectFuture {
+        futures::future::ready(self.disconnect())
     }
 
     pub fn is_ap_enabled(&self) -> Result<bool, EspError> {
@@ -526,6 +577,11 @@ impl<'d> WifiDriver<'d> {
         }
     }
 
+    #[cfg(feature = "async")]
+    pub fn is_started_async(&self) -> IsStartedFuture {
+        futures::future::ready(self.is_started())
+    }
+
     pub fn is_connected(&self) -> Result<bool, EspError> {
         let ap_enabled = self.is_ap_enabled()?;
         let sta_enabled = self.is_sta_enabled()?;
@@ -538,6 +594,11 @@ impl<'d> WifiDriver<'d> {
             Ok((!ap_enabled || guard.1 == WifiEvent::ApStarted)
                 && (!sta_enabled || guard.0 == WifiEvent::StaConnected))
         }
+    }
+
+    #[cfg(feature = "async")]
+    pub fn is_connected_async(&self) -> IsConnectedFuture {
+        futures::future::ready(self.is_connected())
     }
 
     #[allow(non_upper_case_globals)]
@@ -560,6 +621,11 @@ impl<'d> WifiDriver<'d> {
         info!("Configuration gotten: {:?}", &conf);
 
         Ok(conf)
+    }
+
+    #[cfg(feature = "async")]
+    pub fn get_configuration_async(&self) -> GetConfigurationFuture {
+        futures::future::ready(self.get_configuration())
     }
 
     pub fn set_configuration(&mut self, conf: &Configuration) -> Result<(), EspError> {
@@ -604,6 +670,11 @@ impl<'d> WifiDriver<'d> {
         Ok(())
     }
 
+    #[cfg(feature = "async")]
+    pub fn set_configuration_async(&mut self, conf: &Configuration) -> SetConfigurationFuture {
+        futures::future::ready(self.set_configuration(conf))
+    }
+
     /// Scan for nearby, visible access points.
     ///
     /// It scans for all available access points nearby, but returns only the first `N` access points found.
@@ -636,11 +707,21 @@ impl<'d> WifiDriver<'d> {
     /// dynamically.
     ///
     /// For more details see [`WifiDriver::scan_n()`].
+    #[cfg(feature = "async")]
+    pub fn scan_n_async<const N: usize>(&mut self) -> ScanNFuture<N> {
+        futures::future::ready(self.scan_n())
+    }
+
     // For backwards compatibility
     #[cfg(feature = "alloc")]
     pub fn scan(&mut self) -> Result<alloc::vec::Vec<AccessPointInfo>, EspError> {
         self.start_scan(&Default::default(), true)?;
         self.get_scan_result()
+    }
+
+    #[cfg(feature = "async")]
+    pub fn scan_async(&mut self) -> ScanFuture {
+        futures::future::ready(self.scan())
     }
 
     /// Start scanning for nearby, visible access points.
@@ -1446,109 +1527,89 @@ impl WifiWait {
     }
 }
 
-#[cfg(all(feature = "async"))]
-pub struct EspAsyncWifiDriver<'d> {
-    sync: WifiDriver<'d>,
+#[cfg(feature = "async")]
+pub struct AsyncWifiDriver<'d, T>
+where
+    T: BorrowMut<WifiDriver<'d>>,
+{
+    base_driver: T,
+    _p: PhantomData<WifiDriver<'d>>,
 }
 
-#[cfg(all(feature = "async"))]
-impl<'d> EspAsyncWifiDriver<'d> {
+#[cfg(feature = "async")]
+impl<'d, T> AsyncWifiDriver<'d, T>
+where
+    T: BorrowMut<WifiDriver<'d>>,
+{
     #[cfg(all(feature = "alloc", esp_idf_comp_nvs_flash_enabled))]
-    pub fn new<M: WifiModemPeripheral>(
-        modem: impl Peripheral<P = M> + 'd,
-        sysloop: EspSystemEventLoop,
-        nvs: Option<EspDefaultNvsPartition>,
-    ) -> Result<Self, EspError> {
-        Ok(EspAsyncWifiDriver {
-            sync: WifiDriver::new(modem, sysloop, nvs)?,
+    pub fn new(base_driver: T) -> Result<Self, EspError> {
+        Ok(AsyncWifiDriver {
+            base_driver,
+            _p: PhantomData,
         })
     }
 }
 
 #[cfg(all(feature = "async"))]
-impl<'d> asynch::Wifi for EspAsyncWifiDriver<'d> {
+impl<'d, T> asynch::Wifi for AsyncWifiDriver<'d, T>
+where
+    T: BorrowMut<WifiDriver<'d>>,
+{
     type Error = EspError;
 
-    type GetCapabilitiesFuture<'a>
-    = futures::future::Ready<Result<EnumSet<Capability>, Self::Error>> where Self: 'a;
-
-    type GetConfigurationFuture<'a> = futures::future::Ready<Result<Configuration, Self::Error>> where Self: 'a;
-
-    type SetConfigurationFuture<'a> = futures::future::Ready<Result<(), Self::Error>> where Self: 'a;
-
-    type StartFuture<'a> = futures::future::Ready<Result<(), Self::Error>>
-    where
-        Self: 'a;
-
-    type StopFuture<'a> = futures::future::Ready<Result<(), Self::Error>>
-    where
-        Self: 'a;
-
-    type ConnectFuture<'a> = futures::future::Ready<Result<(), Self::Error>>
-    where
-        Self: 'a;
-
-    type DisconnectFuture<'a> = futures::future::Ready<Result<(), Self::Error>>
-    where
-        Self: 'a;
-
-    type IsStartedFuture<'a> = futures::future::Ready<Result<bool, Self::Error>>
-    where
-        Self: 'a;
-
-    type IsConnectedFuture<'a> = futures::future::Ready<Result<bool, Self::Error>>
-    where
-        Self: 'a;
-
-    type ScanNFuture<'a, const N: usize> = futures::future::Ready<Result<(heapless::Vec<AccessPointInfo, N>, usize), Self::Error>>
-    where
-        Self: 'a;
-
-    type ScanFuture<'a> = futures::future::Ready<Result<alloc::vec::Vec<AccessPointInfo>, Self::Error>>
-    where
-        Self: 'a;
+    type GetCapabilitiesFuture<'a> = GetCapabilitiesFuture where Self: 'a;
+    type GetConfigurationFuture<'a> = GetConfigurationFuture where Self: 'a;
+    type SetConfigurationFuture<'a> = SetConfigurationFuture where Self: 'a;
+    type StartFuture<'a> = StartFuture where Self: 'a;
+    type StopFuture<'a> = StopFuture where Self: 'a;
+    type ConnectFuture<'a> = ConnectFuture where Self: 'a;
+    type DisconnectFuture<'a> = DisconnectFuture where Self: 'a;
+    type IsStartedFuture<'a> = IsStartedFuture where Self: 'a;
+    type IsConnectedFuture<'a> = IsConnectedFuture where Self: 'a;
+    type ScanNFuture<'a, const N: usize> = ScanNFuture<N> where Self: 'a;
+    type ScanFuture<'a> = ScanFuture where Self: 'a;
 
     fn get_capabilities(&self) -> Self::GetCapabilitiesFuture<'_> {
-        futures::future::ready(self.sync.get_capabilities())
+        self.base_driver.borrow().get_capabilities_async()
     }
 
     fn get_configuration(&self) -> Self::GetConfigurationFuture<'_> {
-        futures::future::ready(self.sync.get_configuration())
+        self.base_driver.borrow().get_configuration_async()
     }
 
     fn set_configuration(&mut self, conf: &Configuration) -> Self::SetConfigurationFuture<'_> {
-        futures::future::ready(self.sync.set_configuration(conf))
+        self.base_driver.borrow_mut().set_configuration_async(conf)
     }
 
     fn start(&mut self) -> Self::StartFuture<'_> {
-        futures::future::ready(self.sync.start())
+        self.base_driver.borrow_mut().start_async()
     }
 
     fn stop(&mut self) -> Self::StopFuture<'_> {
-        futures::future::ready(self.sync.stop())
+        self.base_driver.borrow_mut().stop_async()
     }
 
     fn connect(&mut self) -> Self::ConnectFuture<'_> {
-        futures::future::ready(self.sync.connect())
+        self.base_driver.borrow_mut().connect_async()
     }
 
     fn disconnect(&mut self) -> Self::DisconnectFuture<'_> {
-        futures::future::ready(self.sync.disconnect())
+        self.base_driver.borrow_mut().disconnect_async()
     }
 
     fn is_started(&self) -> Self::IsStartedFuture<'_> {
-        futures::future::ready(self.sync.is_started())
+        self.base_driver.borrow().is_started_async()
     }
 
     fn is_connected(&self) -> Self::IsConnectedFuture<'_> {
-        futures::future::ready(self.sync.is_connected())
+        self.base_driver.borrow().is_connected_async()
     }
 
     fn scan_n<const N: usize>(&mut self) -> Self::ScanNFuture<'_, N> {
-        futures::future::ready(self.sync.scan_n())
+        self.base_driver.borrow_mut().scan_n_async()
     }
 
     fn scan(&mut self) -> Self::ScanFuture<'_> {
-        futures::future::ready(self.sync.scan())
+        self.base_driver.borrow_mut().scan_async()
     }
 }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -18,8 +18,9 @@ use esp_idf_hal::peripheral::Peripheral;
 
 use esp_idf_sys::*;
 
-#[cfg(feature = "nightly")]
 use core::borrow::BorrowMut;
+#[cfg(all(feature = "nightly", feature = "experimental"))]
+use futures::Future;
 
 use crate::eventloop::EspEventLoop;
 use crate::eventloop::{
@@ -1446,7 +1447,6 @@ impl WifiWait {
     }
 }
 
-#[cfg(feature = "nightly")]
 pub struct AsyncWifiDriver<'d, T>
 where
     T: BorrowMut<WifiDriver<'d>>,
@@ -1455,7 +1455,6 @@ where
     _p: PhantomData<WifiDriver<'d>>,
 }
 
-#[cfg(feature = "nightly")]
 impl<'d, T> AsyncWifiDriver<'d, T>
 where
     T: BorrowMut<WifiDriver<'d>>,
@@ -1522,7 +1521,7 @@ where
     }
 }
 
-#[cfg(all(feature = "nighty", feature = "experimental"))]
+#[cfg(all(feature = "nightly", feature = "experimental"))]
 impl<'d, T> asynch::Wifi for AsyncWifiDriver<'d, T>
 where
     T: BorrowMut<WifiDriver<'d>>,
@@ -1532,14 +1531,14 @@ where
     type GetCapabilitiesFuture<'a> = futures::future::Ready<Result<EnumSet<Capability>, EspError>> where Self: 'a;
     type GetConfigurationFuture<'a> = futures::future::Ready<Result<Configuration, EspError>> where Self: 'a;
     type SetConfigurationFuture<'a> = futures::future::Ready<Result<(), EspError>> where Self: 'a;
-    type StartFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<(), EspError>> + 'a>> where Self: 'a;
-    type StopFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<(), EspError>> + 'a>> where Self: 'a;
-    type ConnectFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<(), EspError>> + 'a>> where Self: 'a;
-    type DisconnectFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<(), EspError>> + 'a>> where Self: 'a;
     type IsStartedFuture<'a> = futures::future::Ready<Result<bool, EspError>> where Self: 'a;
     type IsConnectedFuture<'a> = futures::future::Ready<Result<bool, EspError>> where Self: 'a;
-    type ScanNFuture<'a, const N: usize> = Pin<Box<dyn futures::future::Future<Output = Result<(heapless::Vec<AccessPointInfo, N>, usize), EspError>> + 'a>> where Self: 'a;
-    type ScanFuture<'a> = Pin<Box<dyn futures::future::Future<Output = Result<alloc::vec::Vec<AccessPointInfo>, EspError>> + 'a>> where Self: 'a;
+    type StartFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
+    type StopFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
+    type ConnectFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
+    type DisconnectFuture<'a> = impl Future<Output = Result<(), Self::Error>> + 'a where Self: 'a;
+    type ScanNFuture<'a, const N: usize> = impl Future<Output = Result<(heapless::Vec<AccessPointInfo, N>, usize), Self::Error>> + 'a where Self: 'a;
+    type ScanFuture<'a> = impl Future<Output = Result<alloc::vec::Vec<AccessPointInfo>, Self::Error>> + 'a where Self: 'a;
 
     fn get_capabilities(&self) -> Self::GetCapabilitiesFuture<'_> {
         futures::future::ready(self.get_capabilities())
@@ -1554,20 +1553,19 @@ where
     }
 
     fn start(&mut self) -> Self::StartFuture<'_> {
-        // let a = self.start();
-        Box::pin(self.start())
+        self.start()
     }
 
     fn stop(&mut self) -> Self::StopFuture<'_> {
-        Box::pin(self.stop())
+        self.stop()
     }
 
     fn connect(&mut self) -> Self::ConnectFuture<'_> {
-        Box::pin(self.connect())
+        self.connect()
     }
 
     fn disconnect(&mut self) -> Self::DisconnectFuture<'_> {
-        Box::pin(self.disconnect())
+        self.disconnect()
     }
 
     fn is_started(&self) -> Self::IsStartedFuture<'_> {
@@ -1579,10 +1577,10 @@ where
     }
 
     fn scan_n<const N: usize>(&mut self) -> Self::ScanNFuture<'_, N> {
-        Box::pin(self.scan_n())
+        self.scan_n()
     }
 
     fn scan(&mut self) -> Self::ScanFuture<'_> {
-        Box::pin(self.scan())
+        self.scan()
     }
 }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -11,6 +11,9 @@ use ::log::*;
 
 use enumset::*;
 
+#[cfg(all(feature = "nightly", feature = "experimental"))]
+use embedded_svc::wifi::asynch;
+
 use embedded_svc::wifi::*;
 
 use esp_idf_hal::modem::WifiModemPeripheral;
@@ -1440,5 +1443,112 @@ impl WifiWait {
         ) {
             waitable.cvar.notify_all();
         }
+    }
+}
+
+#[cfg(all(feature = "nightly", feature = "experimental"))]
+pub struct EspAsyncWifiDriver<'d> {
+    sync: WifiDriver<'d>,
+}
+
+#[cfg(all(feature = "nightly", feature = "experimental"))]
+impl<'d> EspAsyncWifiDriver<'d> {
+    #[cfg(all(feature = "alloc", esp_idf_comp_nvs_flash_enabled))]
+    pub fn new<M: WifiModemPeripheral>(
+        modem: impl Peripheral<P = M> + 'd,
+        sysloop: EspSystemEventLoop,
+        nvs: Option<EspDefaultNvsPartition>,
+    ) -> Result<Self, EspError> {
+        Ok(EspAsyncWifiDriver {
+            sync: WifiDriver::new(modem, sysloop, nvs)?,
+        })
+    }
+}
+
+#[cfg(all(feature = "nightly", feature = "experimental"))]
+impl<'d> asynch::Wifi for EspAsyncWifiDriver<'d> {
+    type Error = EspError;
+
+    type GetCapabilitiesFuture<'a>
+    = futures::future::Ready<Result<EnumSet<Capability>, Self::Error>> where Self: 'a;
+
+    type GetConfigurationFuture<'a> = futures::future::Ready<Result<Configuration, Self::Error>> where Self: 'a;
+
+    type SetConfigurationFuture<'a> = futures::future::Ready<Result<(), Self::Error>> where Self: 'a;
+
+    type StartFuture<'a> = futures::future::Ready<Result<(), Self::Error>>
+    where
+        Self: 'a;
+
+    type StopFuture<'a> = futures::future::Ready<Result<(), Self::Error>>
+    where
+        Self: 'a;
+
+    type ConnectFuture<'a> = futures::future::Ready<Result<(), Self::Error>>
+    where
+        Self: 'a;
+
+    type DisconnectFuture<'a> = futures::future::Ready<Result<(), Self::Error>>
+    where
+        Self: 'a;
+
+    type IsStartedFuture<'a> = futures::future::Ready<Result<bool, Self::Error>>
+    where
+        Self: 'a;
+
+    type IsConnectedFuture<'a> = futures::future::Ready<Result<bool, Self::Error>>
+    where
+        Self: 'a;
+
+    type ScanNFuture<'a, const N: usize> = futures::future::Ready<Result<(heapless::Vec<AccessPointInfo, N>, usize), Self::Error>>
+    where
+        Self: 'a;
+
+    type ScanFuture<'a> = futures::future::Ready<Result<alloc::vec::Vec<AccessPointInfo>, Self::Error>>
+    where
+        Self: 'a;
+
+    fn get_capabilities(&self) -> Self::GetCapabilitiesFuture<'_> {
+        futures::future::ready(self.sync.get_capabilities())
+    }
+
+    fn get_configuration(&self) -> Self::GetConfigurationFuture<'_> {
+        futures::future::ready(self.sync.get_configuration())
+    }
+
+    fn set_configuration(&mut self, conf: &Configuration) -> Self::SetConfigurationFuture<'_> {
+        futures::future::ready(self.sync.set_configuration(conf))
+    }
+
+    fn start(&mut self) -> Self::StartFuture<'_> {
+        futures::future::ready(self.sync.start())
+    }
+
+    fn stop(&mut self) -> Self::StopFuture<'_> {
+        futures::future::ready(self.sync.stop())
+    }
+
+    fn connect(&mut self) -> Self::ConnectFuture<'_> {
+        futures::future::ready(self.sync.connect())
+    }
+
+    fn disconnect(&mut self) -> Self::DisconnectFuture<'_> {
+        futures::future::ready(self.sync.disconnect())
+    }
+
+    fn is_started(&self) -> Self::IsStartedFuture<'_> {
+        futures::future::ready(self.sync.is_started())
+    }
+
+    fn is_connected(&self) -> Self::IsConnectedFuture<'_> {
+        futures::future::ready(self.sync.is_connected())
+    }
+
+    fn scan_n<const N: usize>(&mut self) -> Self::ScanNFuture<'_, N> {
+        futures::future::ready(self.sync.scan_n())
+    }
+
+    fn scan(&mut self) -> Self::ScanFuture<'_> {
+        futures::future::ready(self.sync.scan())
     }
 }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1519,7 +1519,7 @@ where
     }
 
     pub async fn start(&mut self) -> Result<(), WifiError> {
-        self.event_wait_helper(
+        self.event_dual_wait_helper(
             WifiEvent::StaStarted,
             Ok(()),
             WifiEvent::StaStopped,
@@ -1530,30 +1530,28 @@ where
     }
 
     pub async fn stop(&mut self) -> Result<(), WifiError> {
-        self.event_wait_helper(
-            WifiEvent::StaStopped,
-            Ok(()),
-            WifiEvent::StaStarted,
-            Err(WifiError::Unknown),
-            |s: &mut Self| s.base_driver.borrow_mut().stop(),
-        )
+        self.event_wait(WifiEvent::StaStopped, |s: &mut Self| {
+            s.base_driver.borrow_mut().stop()
+        })
         .await
     }
 
     pub async fn connect(&mut self) -> Result<(), WifiError> {
-        self.base_driver
-            .borrow_mut()
-            .connect()
-            .map_err(|err| err.into())
-        // TODO: wait until connect is complete
+        self.event_dual_wait_helper(
+            WifiEvent::StaConnected,
+            Ok(()),
+            WifiEvent::StaDisconnected,
+            Err(WifiError::Disconnected),
+            |s: &mut Self| s.base_driver.borrow_mut().connect(),
+        )
+        .await
     }
 
     pub async fn disconnect(&mut self) -> Result<(), WifiError> {
-        self.base_driver
-            .borrow_mut()
-            .disconnect()
-            .map_err(|err| err.into())
-        // TODO: wait until stop is complete
+        self.event_wait(WifiEvent::StaDisconnected, |s: &mut Self| {
+            s.base_driver.borrow_mut().disconnect()
+        })
+        .await
     }
 
     pub async fn scan_n<const N: usize>(
@@ -1572,7 +1570,21 @@ where
         base.scan().map_err(|err| err.into())
     }
 
-    async fn event_wait_helper<F>(
+    async fn event_wait<F>(&mut self, trigger_event: WifiEvent, action: F) -> Result<(), WifiError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), EspError>,
+    {
+        let mut future = WifiEventFuture::new();
+        let sysloop = &self.base_driver.borrow().sysloop;
+        future.start(sysloop, trigger_event)?;
+
+        action(self)?;
+
+        future.await;
+        Ok(())
+    }
+
+    async fn event_dual_wait_helper<F>(
         &mut self,
         event1: WifiEvent,
         result1: Result<(), WifiError>,
@@ -1684,6 +1696,51 @@ where
         me.resolution = Some(resolution);
         me.atomic_waker.wake();
         me.subscription.take();
+    }
+}
+
+struct WifiEventFuture {
+    internal_data: Arc<Mutex<WifiEventFutureData<()>>>,
+}
+
+impl WifiEventFuture {
+    pub fn new() -> Self {
+        Self {
+            internal_data: Arc::new(Mutex::new(WifiEventFutureData::new())),
+        }
+    }
+
+    pub fn start(
+        &mut self,
+        sysloop: &EspEventLoop<System>,
+        trigger_event: WifiEvent,
+    ) -> Result<(), EspError> {
+        let mut copied_data = self.internal_data.clone();
+        let mut internal_data = self.internal_data.borrow_mut().lock();
+
+        internal_data.subscription = Some(sysloop.subscribe(move |event: &WifiEvent| {
+            if *event == trigger_event {
+                WifiEventFutureData::resolve(&mut copied_data, ())
+            }
+        })?);
+        Ok(())
+    }
+}
+
+impl core::future::Future for WifiEventFuture {
+    type Output = ();
+
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        let mut internal_data = self.internal_data.lock();
+        internal_data.atomic_waker.register(cx.waker());
+        if internal_data.resolution.is_some() {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
     }
 }
 


### PR DESCRIPTION
The stubs just block on the sync variants of the functions, and return a 'ready' future. In a later iteration, the async functions that block can be replaced with proper futures. Also added an example of using the async Wifi.

Feedback and comments welcome!