### PR TITLE
Set number of encrypted peers supported by espnow

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -421,6 +421,7 @@ impl<'d> WifiDriver<'d> {
             mgmt_sbuf_num: WIFI_MGMT_SBUF_NUM as _,
             feature_caps: unsafe { g_wifi_feature_caps },
             sta_disconnected_pm: WIFI_STA_DISCONNECTED_PM_ENABLED != 0,
+            espnow_max_encrypt_num: CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM as i32,
             magic: WIFI_INIT_CONFIG_MAGIC as _,
             ..Default::default()
         };


### PR DESCRIPTION
[esp-idf added](https://github.com/espressif/esp-idf/commit/5c1ff3d7) the field `espnow_max_encrypt_num` to `wifi_init_config_t` which controls how many encrypted peers can be added.

If it's initialized to 0, none can be added.
C code would use the macro `WIFI_INIT_CONFIG_DEFAULT` to do the initialization, setting its value to `CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM` configured by the user.
This change does the same in Rust.