### PR TITLE
Add methods to query content length before receiving

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -689,6 +689,11 @@ impl<'a> EspHttpConnection<'a> {
         self.headers.is_none()
     }
 
+    #[inline(always)]
+    pub fn content_len(&self) -> usize {
+        self.request.0.content_len
+    }
+
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, EspError> {
         self.assert_request();
 


### PR DESCRIPTION
With this code it will now be possible to query for incoming content size before attempting to receive any data. Users can query the content length and ensure a buffer capacity or send a graceful fail message to the client.

Calling `content_len()` does not require invariant checks so it can be inlined, but I can add the invariant check if you insist. :)

## Example usage: JSON POST handler

```Rust
#[derive(Deserialize)]
struct FormData<'a> {
    first_name: &'a str,
    last_name: &'a str
}

// ...

server.fn_handler("/post", Method::Post, |mut req| {
    let len = req.connection().content_len();

    if len > MAX_LEN {
        req.into_status_response(413)?
            .write_all("Request too big".as_bytes())?;
        return Ok(());
    }

    let mut buf = vec![0; len];
    req.read_exact(&mut buf)?;
    let mut resp = req.into_ok_response()?;

    if let Ok(form) = serde_json::from_slice::<FormData>(&buf) {
        write!(resp, "Your first name is `{}` and last name is `{}`.", form.first_name, form.last_name)?;
    } else {
        resp.write_all("JSON error".as_bytes())?;
    }

    Ok(())
}).unwrap();
```