### PR TITLE
Add eth get_handle fn

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -838,6 +838,10 @@ impl<'d, T> EspEth<'d, T> {
         &mut self.driver
     }
 
+    pub fn get_handle(&self) -> esp_eth_handle_t {
+        self.driver.handle
+    }
+    
     pub fn netif(&self) -> &EspNetif {
         &self.netif
     }


### PR DESCRIPTION
Adding get_handle function to eth to give control over the esp_eth_mediator_s to edit the phy_reg for custom eth hardware.