### PR TITLE
Set negative value to second argument of `esp_http_client_open` method if request header has `Transfer-Encoding: chunked`

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -101,7 +101,7 @@ pub struct EspHttpConnection {
     follow_redirects_policy: FollowRedirectsPolicy,
     event_handler: Box<Option<Box<dyn Fn(&esp_http_client_event_t) -> esp_err_t>>>,
     state: State,
-    request_content_len: i32,
+    request_content_len: u64,
     follow_redirects: bool,
     headers: BTreeMap<Uncased<'static>, String>,
     content_len_header: UnsafeCell<Option<Option<String>>>,
@@ -221,7 +221,7 @@ impl EspHttpConnection {
 
         for (name, value) in headers {
             if name.eq_ignore_ascii_case("Content-Length") {
-                if let Ok(len) = value.parse::<i32>() {
+                if let Ok(len) = value.parse::<u64>() {
                     content_len = Some(len);
                 }
             }
@@ -254,7 +254,7 @@ impl EspHttpConnection {
                 if self.is_chunked_streaming_request(headers) {
                     -1
                 } else {
-                    self.request_content_len
+                    self.request_content_len as i32
                 },
             )
         })?;
@@ -408,7 +408,7 @@ impl EspHttpConnection {
                     })?;
                     esp!(unsafe { esp_http_client_set_redirection(self.raw_client) })?;
                     esp!(unsafe {
-                        esp_http_client_open(self.raw_client, self.request_content_len)
+                        esp_http_client_open(self.raw_client, self.request_content_len as i32)
                     })?;
 
                     self.headers.clear();

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -101,7 +101,7 @@ pub struct EspHttpConnection {
     follow_redirects_policy: FollowRedirectsPolicy,
     event_handler: Box<Option<Box<dyn Fn(&esp_http_client_event_t) -> esp_err_t>>>,
     state: State,
-    request_content_len: u64,
+    request_content_len: i32,
     follow_redirects: bool,
     headers: BTreeMap<Uncased<'static>, String>,
     content_len_header: UnsafeCell<Option<Option<String>>>,
@@ -221,7 +221,7 @@ impl EspHttpConnection {
 
         for (name, value) in headers {
             if name.eq_ignore_ascii_case("Content-Length") {
-                if let Ok(len) = value.parse::<u64>() {
+                if let Ok(len) = value.parse::<i32>() {
                     content_len = Some(len);
                 }
             }
@@ -248,7 +248,7 @@ impl EspHttpConnection {
 
         self.request_content_len = content_len.unwrap_or(0);
 
-        esp!(unsafe { esp_http_client_open(self.raw_client, self.request_content_len as _) })?;
+        esp!(unsafe { esp_http_client_open(self.raw_client, self.request_content_len) })?;
 
         self.state = State::Request;
 
@@ -399,7 +399,7 @@ impl EspHttpConnection {
                     })?;
                     esp!(unsafe { esp_http_client_set_redirection(self.raw_client) })?;
                     esp!(unsafe {
-                        esp_http_client_open(self.raw_client, self.request_content_len as _)
+                        esp_http_client_open(self.raw_client, self.request_content_len)
                     })?;
 
                     self.headers.clear();


### PR DESCRIPTION
## What

Set nevative value to `request_content_len` property if can't unwrap `content_len` somehow.

## Why

Ref: https://github.com/esp-rs/esp-idf-svc/issues/309

I want to implement streaming http post that sets `Transfer-Encoding: chunked` to the header and doesn't set `Content-Length`. But this library sets `Content-Length: 0` if I don't set `Content-Length` to the header and got 400 error (Please read above issue description).

As I investigate, I can avoid this behavior and can get what I'm looking for if set negative value to the second argument of  `esp_http_client_open` method.
https://github.com/esp-rs/esp-idf-svc/issues/309#issuecomment-1783754746

So I want to set negative value if can't fetch correct value from `content_len`.

## How

Set `request_content_len` type to i64 because I want to set negative value to it, and set `request_content_len` property to -1 (Some negative value) if can't unwrap `content_len`.