### PR TITLE
[nits] Convert request_content_len to i32 because it would be casted to i32 finally

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -101,7 +101,7 @@ pub struct EspHttpConnection {
     follow_redirects_policy: FollowRedirectsPolicy,
     event_handler: Box<Option<Box<dyn Fn(&esp_http_client_event_t) -> esp_err_t>>>,
     state: State,
-    request_content_len: u64,
+    request_content_len: i32,
     follow_redirects: bool,
     headers: BTreeMap<Uncased<'static>, String>,
     content_len_header: UnsafeCell<Option<Option<String>>>,
@@ -221,7 +221,7 @@ impl EspHttpConnection {
 
         for (name, value) in headers {
             if name.eq_ignore_ascii_case("Content-Length") {
-                if let Ok(len) = value.parse::<u64>() {
+                if let Ok(len) = value.parse::<i32>() {
                     content_len = Some(len);
                 }
             }
@@ -248,7 +248,7 @@ impl EspHttpConnection {
 
         self.request_content_len = content_len.unwrap_or(0);
 
-        esp!(unsafe { esp_http_client_open(self.raw_client, self.request_content_len as _) })?;
+        esp!(unsafe { esp_http_client_open(self.raw_client, self.request_content_len) })?;
 
         self.state = State::Request;
 
@@ -399,7 +399,7 @@ impl EspHttpConnection {
                     })?;
                     esp!(unsafe { esp_http_client_set_redirection(self.raw_client) })?;
                     esp!(unsafe {
-                        esp_http_client_open(self.raw_client, self.request_content_len as _)
+                        esp_http_client_open(self.raw_client, self.request_content_len)
                     })?;
 
                     self.headers.clear();


### PR DESCRIPTION
## What

Make type of `request_content_len` property in `EspHttpConnection` struct from `u64` to `i32`.

## Why

Now I'm working on https://github.com/esp-rs/esp-idf-svc/pull/310 . I noticed the second argument of `esp_http_client_open` method expects `i32` value, not `u64`. But `request_content_len` type is `u64`. I investigated `requset_content_len` property but it seems there is no reason that `request_content_len` type should be `u64`. So I want to modify it to `i32` because it would make more easier to implement https://github.com/esp-rs/esp-idf-svc/pull/310 .

When I remove `as _` from https://github.com/esp-rs/esp-idf-svc/blob/master/src/http/client.rs#L251 , then shows the error as below.
```
      |         esp!(unsafe { esp_http_client_open(self.raw_client, self.request_content_len) })?;
      |                       --------------------                  ^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u64`
      |                       |
      |                       arguments to this function are incorrect
```

## How

Replace `u64` type with `i32` of `request_content_len` property. Then remove `as _` syntax for them because now it has expected type.