### PR TITLE
Set ping TTL to 64 (fixes #318)

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -77,6 +77,7 @@ impl EspPing {
             task_stack_size: 4096,
             task_prio: 2,
             interface: self.0,
+            ttl: 64,
             ..Default::default()
         };
 


### PR DESCRIPTION
The default TTL is 0, ie pinging any host that isn't on the local network will fail - with this, it succeeds