### PR TITLE
Fix EspWebSocketClient issues and add websocket_client example

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,3 +19,6 @@ ESP_IDF_SDKCONFIG_DEFAULTS = ".github/configs/sdkconfig.defaults"
 [unstable]
 build-std = ["std", "panic_abort"]
 build-std-features = ["panic_immediate_abort"]
+
+[build]
+rustflags = "--cfg espidf_time64"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,5 +20,7 @@ ESP_IDF_SDKCONFIG_DEFAULTS = ".github/configs/sdkconfig.defaults"
 build-std = ["std", "panic_abort"]
 build-std-features = ["panic_immediate_abort"]
 
-[build]
-rustflags = "--cfg espidf_time64"
+# Configure the espidf_time64 Rust compiler flag to build with ESP-IDF 5.*.
+# Must be disabled to build with ESP-IDF 4.*.
+# [build]
+# rustflags = "--cfg espidf_time64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          ESP_IDF_COMPONENT_MANAGER: "${{ matrix.idf-version == 'v5.1.1' && 'y' || 'n'}}"
           RUSTFLAGS: "${{ matrix.idf-version == 'v5.1.1' && '--cfg espidf_time64' || ''}}"
         run: cargo clippy --features nightly,experimental --no-deps --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort -- -Dwarnings
 
@@ -58,6 +59,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          ESP_IDF_COMPONENT_MANAGER: "${{ matrix.idf-version == 'v5.1.1' && 'y' || 'n'}}"
           RUSTFLAGS: "${{ matrix.idf-version == 'v5.1.1' && '--cfg espidf_time64' || ''}}"
         run: cargo build --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
@@ -65,6 +67,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          ESP_IDF_COMPONENT_MANAGER: "${{ matrix.idf-version == 'v5.1.1' && 'y' || 'n'}}"
           RUSTFLAGS: "${{ matrix.idf-version == 'v5.1.1' && '--cfg espidf_time64' || ''}}"
         run: cargo build --no-default-features --features nightly,experimental --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
@@ -72,6 +75,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          ESP_IDF_COMPONENT_MANAGER: "${{ matrix.idf-version == 'v5.1.1' && 'y' || 'n'}}"
           RUSTFLAGS: "${{ matrix.idf-version == 'v5.1.1' && '--cfg espidf_time64' || ''}}"
         run: cargo build --no-default-features --features nightly,experimental,alloc --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
 
@@ -86,6 +90,7 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"
+          ESP_IDF_COMPONENT_MANAGER: "${{ matrix.idf-version == 'v5.1.1' && 'y' || 'n'}}"
           RUSTFLAGS: "${{ matrix.idf-version == 'v5.1.1' && '--cfg espidf_time64 ' || ''}} ${{ '-C default-linker-libraries' }}"
           WIFI_SSID: "ssid"
           WIFI_PASS: "pass"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ name = "ws_guessing_game"
 # Add the esp_websocket_client extra component to build the websocket_client
 # example with ESP-IDF 5.*, which doesn't include the component by default.
 # Must be disabled to build the websocket_client example with ESP-IDF 4.*,
-# which does include the component by default.
-# [[package.metadata.esp-idf-sys.extra_components]]
-# remote_component = { name = "espressif/esp_websocket_client", version = "1.1.0" }
+# which includes an earlier version of the component by default, and which isn't
+# compatible with the version of the client in the component registry.
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/esp_websocket_client", version = "1.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,10 @@ name = "json_post_handler"
 
 [[example]]
 name = "ws_guessing_game"
+
+# Add the esp_websocket_client extra component to build the websocket_client
+# example with ESP-IDF 5.*, which doesn't include the component by default.
+# Must be disabled to build the websocket_client example with ESP-IDF 4.*,
+# which does include the component by default.
+# [[package.metadata.esp-idf-sys.extra_components]]
+# remote_component = { name = "espressif/esp_websocket_client", version = "1.1.0" }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ with older `cargo-espflash`:
 $ ESP_IDF_VERSION=release/v4.4 cargo espflash --target riscv32imc-esp-espidf --example ledc_simple --monitor /dev/ttyUSB0
 ```
 
+## Building with ESP IDF 5
+
+To build with ESP IDF 5.\*, you must configure rustflags with espidf_time64 in .cargo/config.toml:
+```
+[build]
+rustflags = "--cfg espidf_time64"
+```
+
+To build the websocket_client example with ESP IDF 5.\*, you must also add the esp_websocket_client extra component in Cargo.toml:
+```
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/esp_websocket_client", version = "1.1.0" }
+```
+
 ## Setting up a "Hello, world!" binary crate with ESP IDF
 
 Use the [esp-idf-template](https://github.com/esp-rs/esp-idf-template) project. Everything would be arranged and built for you automatically - no need to manually clone the ESP IDF repository.

--- a/components_esp32s3.lock
+++ b/components_esp32s3.lock
@@ -1,0 +1,15 @@
+dependencies:
+  espressif/esp_websocket_client:
+    component_hash: 3f3b04c060ca52c8a06b96b39f22f50086f2bb41d9e9a2411e809cf6b7edfa60
+    source:
+      service_url: https://api.components.espressif.com/
+      type: service
+    version: 1.1.0
+  idf:
+    component_hash: null
+    source:
+      type: idf
+    version: 5.1.2
+manifest_hash: 5dc0694d3daee473808b32239e49a3a09da865f4ad83ed897a33abaad17c370b
+target: esp32s3
+version: 1.0.0

--- a/examples/websocket_client.rs
+++ b/examples/websocket_client.rs
@@ -3,7 +3,7 @@
 //! This example connects to a websocket server that echoes messages,
 //! sends a message, receives the same message, and closes the connection.
 
-use core::time::Duration;
+use core::{ffi::CStr, time::Duration};
 
 use embedded_svc::{
     wifi::{AuthMethod, ClientConfiguration, Configuration},
@@ -16,10 +16,10 @@ use esp_idf_svc::{
     io::EspIOError,
     log::EspLogger,
     nvs::EspDefaultNvsPartition,
+    tls::X509,
     wifi::{BlockingWifi, EspWifi},
     ws::client::{
-        EspWebSocketClient, EspWebSocketClientConfig, EspWebSocketX509Encoding, WebSocketEvent,
-        WebSocketEventType,
+        EspWebSocketClient, EspWebSocketClientConfig, WebSocketEvent, WebSocketEventType,
     },
 };
 
@@ -65,7 +65,7 @@ oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
 mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
 emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 -----END CERTIFICATE-----
-";
+\0";
 
 /// The relevant events for this example as it connects to the server,
 /// sends a message, receives the same message, and closes the connection.
@@ -92,7 +92,9 @@ fn main() -> anyhow::Result<()> {
 
     // Connect websocket
     let config = EspWebSocketClientConfig {
-        server_cert: Some(EspWebSocketX509Encoding::PEM(SERVER_ROOT_CERT)),
+        server_cert: Some(X509::pem(
+            CStr::from_bytes_with_nul(SERVER_ROOT_CERT.as_bytes()).unwrap(),
+        )),
         ..Default::default()
     };
     let timeout = Duration::from_secs(10);

--- a/examples/websocket_client.rs
+++ b/examples/websocket_client.rs
@@ -120,10 +120,10 @@ fn main() -> anyhow::Result<()> {
 
 fn connect_wifi(wifi: &mut BlockingWifi<EspWifi<'static>>) -> anyhow::Result<()> {
     let wifi_configuration: Configuration = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
+        ssid: SSID.try_into().unwrap(),
         bssid: None,
         auth_method: AuthMethod::WPA2Personal,
-        password: PASSWORD.into(),
+        password: PASSWORD.try_into().unwrap(),
         channel: None,
     });
 

--- a/examples/websocket_client.rs
+++ b/examples/websocket_client.rs
@@ -1,0 +1,179 @@
+//! Simple websocket client example.
+//!
+//! This example connects to a websocket server that echoes messages,
+//! sends a message, receives the same message, and closes the connection.
+
+use core::time::Duration;
+
+use embedded_svc::{
+    wifi::{AuthMethod, ClientConfiguration, Configuration},
+    ws::FrameType,
+};
+
+use esp_idf_svc::{
+    eventloop::EspSystemEventLoop,
+    hal::peripherals::Peripherals,
+    io::EspIOError,
+    log::EspLogger,
+    nvs::EspDefaultNvsPartition,
+    wifi::{BlockingWifi, EspWifi},
+    ws::client::{
+        EspWebSocketClient, EspWebSocketClientConfig, EspWebSocketX509Encoding, WebSocketEvent,
+        WebSocketEventType,
+    },
+};
+
+use log::info;
+
+use std::sync::mpsc;
+
+const SSID: &str = env!("WIFI_SSID");
+const PASSWORD: &str = env!("WIFI_PASS");
+const ECHO_SERVER_URI: &str = "wss://echo.websocket.org";
+
+/// The PEM-encoded ISRG Root X1 root certificate at the end of the cert chain
+/// for the websocket server at echo.websocket.org.
+const SERVER_ROOT_CERT: &str = "
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----
+";
+
+/// The relevant events for this example as it connects to the server,
+/// sends a message, receives the same message, and closes the connection.
+#[derive(Debug, PartialEq)]
+enum ExampleEvent {
+    Connected,
+    MessageReceived,
+    Closed,
+}
+
+fn main() -> anyhow::Result<()> {
+    esp_idf_svc::sys::link_patches();
+    EspLogger::initialize_default();
+
+    // Setup Wifi
+    let peripherals = Peripherals::take()?;
+    let sys_loop = EspSystemEventLoop::take()?;
+    let nvs = EspDefaultNvsPartition::take()?;
+    let mut wifi = BlockingWifi::wrap(
+        EspWifi::new(peripherals.modem, sys_loop.clone(), Some(nvs))?,
+        sys_loop,
+    )?;
+    connect_wifi(&mut wifi)?;
+
+    // Connect websocket
+    let config = EspWebSocketClientConfig {
+        server_cert: Some(EspWebSocketX509Encoding::PEM(SERVER_ROOT_CERT)),
+        ..Default::default()
+    };
+    let timeout = Duration::from_secs(10);
+    let (tx, rx) = mpsc::channel::<ExampleEvent>();
+    let mut client = EspWebSocketClient::new(ECHO_SERVER_URI, &config, timeout, move |event| {
+        handle_event(&tx, event)
+    })?;
+    assert_eq!(rx.recv(), Ok(ExampleEvent::Connected));
+    assert!(client.is_connected());
+
+    // Send message and receive it back
+    let message = format!("Hello, World!");
+    info!("Websocket send, text: {}", &message);
+    client.send(FrameType::Text(false), message.as_bytes())?;
+    assert_eq!(rx.recv(), Ok(ExampleEvent::MessageReceived));
+
+    // Close websocket
+    drop(client);
+    assert_eq!(rx.recv(), Ok(ExampleEvent::Closed));
+
+    Ok(())
+}
+
+fn connect_wifi(wifi: &mut BlockingWifi<EspWifi<'static>>) -> anyhow::Result<()> {
+    let wifi_configuration: Configuration = Configuration::Client(ClientConfiguration {
+        ssid: SSID.into(),
+        bssid: None,
+        auth_method: AuthMethod::WPA2Personal,
+        password: PASSWORD.into(),
+        channel: None,
+    });
+
+    wifi.set_configuration(&wifi_configuration)?;
+
+    wifi.start()?;
+    info!("Wifi started");
+
+    wifi.connect()?;
+    info!("Wifi connected");
+
+    wifi.wait_netif_up()?;
+    info!("Wifi netif up");
+
+    Ok(())
+}
+
+fn handle_event(tx: &mpsc::Sender<ExampleEvent>, event: &Result<WebSocketEvent, EspIOError>) {
+    if let Ok(event) = event {
+        match event.event_type {
+            WebSocketEventType::BeforeConnect => {
+                info!("Websocket before connect");
+            }
+            WebSocketEventType::Connected => {
+                info!("Websocket connected");
+                tx.send(ExampleEvent::Connected).ok();
+            }
+            WebSocketEventType::Disconnected => {
+                info!("Websocket disconnected");
+            }
+            WebSocketEventType::Close(reason) => {
+                info!("Websocket close, reason: {reason:?}");
+            }
+            WebSocketEventType::Closed => {
+                info!("Websocket closed");
+                tx.send(ExampleEvent::Closed).ok();
+            }
+            WebSocketEventType::Text(text) => {
+                info!("Websocket recv, text: {text}");
+                if text == "Hello, World!" {
+                    tx.send(ExampleEvent::MessageReceived).ok();
+                }
+            }
+            WebSocketEventType::Binary(binary) => {
+                info!("Websocket recv, binary: {binary:?}");
+            }
+            WebSocketEventType::Ping => {
+                info!("Websocket ping");
+            }
+            WebSocketEventType::Pong => {
+                info!("Websocket pong");
+            }
+        }
+    }
+}

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -228,10 +228,10 @@ impl EspHttpConnection {
                     content_len = Some(len);
                 }
             } else {
-                let c_name = to_cstring_arg(name)?;
+                let c_name = to_cstring_arg(*name)?;
 
                 // TODO: Replace with a proper conversion from UTF8 to ISO-8859-1
-                let c_value = to_cstring_arg(value)?;
+                let c_value = to_cstring_arg(*value)?;
 
                 esp!(unsafe {
                     esp_http_client_set_header(

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -714,20 +714,20 @@ impl<'a> EspHttpConnection<'a> {
 
         for (key, value) in headers {
             if key.eq_ignore_ascii_case("Content-Type") {
-                let c_type = to_cstring_arg(value)?;
+                let c_type = to_cstring_arg(*value)?;
 
                 esp!(unsafe { httpd_resp_set_type(self.request.0, c_type.as_c_str().as_ptr()) })?;
 
                 c_headers.push(c_type);
             } else if key.eq_ignore_ascii_case("Content-Length") {
-                let c_len = to_cstring_arg(value)?;
+                let c_len = to_cstring_arg(*value)?;
 
                 //esp!(unsafe { httpd_resp_set_len(self.raw_req, c_len.as_c_str().as_ptr()) })?;
 
                 c_headers.push(c_len);
             } else {
-                let name = to_cstring_arg(key)?;
-                let value = to_cstring_arg(value)?;
+                let name = to_cstring_arg(*key)?;
+                let value = to_cstring_arg(*value)?;
 
                 esp!(unsafe {
                     httpd_resp_set_hdr(

--- a/src/private/cstr.rs
+++ b/src/private/cstr.rs
@@ -52,7 +52,10 @@ impl RawCstrs {
     }
 
     #[allow(dead_code)]
-    pub fn as_ptr(&mut self, s: impl Into<alloc::vec::Vec<u8>>) -> Result<*const c_char, crate::sys::EspError> {
+    pub fn as_ptr(
+        &mut self,
+        s: impl Into<alloc::vec::Vec<u8>>,
+    ) -> Result<*const c_char, crate::sys::EspError> {
         let cs = to_cstring_arg(s)?;
 
         let cstr_ptr = cs.as_ptr();

--- a/src/private/cstr.rs
+++ b/src/private/cstr.rs
@@ -52,7 +52,7 @@ impl RawCstrs {
     }
 
     #[allow(dead_code)]
-    pub fn as_ptr(&mut self, s: impl Into<Vec<u8>>) -> Result<*const c_char, crate::sys::EspError> {
+    pub fn as_ptr(&mut self, s: impl Into<alloc::vec::Vec<u8>>) -> Result<*const c_char, crate::sys::EspError> {
         let cs = to_cstring_arg(s)?;
 
         let cstr_ptr = cs.as_ptr();
@@ -65,7 +65,7 @@ impl RawCstrs {
     #[allow(dead_code)]
     pub fn as_nptr<S>(&mut self, s: Option<S>) -> Result<*const c_char, crate::sys::EspError>
     where
-        S: Into<Vec<u8>>,
+        S: Into<alloc::vec::Vec<u8>>,
     {
         s.map(|s| self.as_ptr(s)).unwrap_or(Ok(core::ptr::null()))
     }
@@ -88,7 +88,7 @@ pub fn nul_to_invalid_arg(_err: alloc::ffi::NulError) -> crate::sys::EspError {
 #[cfg(feature = "alloc")]
 pub fn to_cstring_arg<S>(value: S) -> Result<CString, crate::sys::EspError>
 where
-    S: Into<Vec<u8>>,
+    S: Into<alloc::vec::Vec<u8>>,
 {
     CString::new(value).map_err(nul_to_invalid_arg)
 }

--- a/src/private/cstr.rs
+++ b/src/private/cstr.rs
@@ -52,8 +52,8 @@ impl RawCstrs {
     }
 
     #[allow(dead_code)]
-    pub fn as_ptr(&mut self, s: impl AsRef<str>) -> Result<*const c_char, crate::sys::EspError> {
-        let cs = to_cstring_arg(s.as_ref())?;
+    pub fn as_ptr(&mut self, s: impl Into<Vec<u8>>) -> Result<*const c_char, crate::sys::EspError> {
+        let cs = to_cstring_arg(s)?;
 
         let cstr_ptr = cs.as_ptr();
 
@@ -65,7 +65,7 @@ impl RawCstrs {
     #[allow(dead_code)]
     pub fn as_nptr<S>(&mut self, s: Option<S>) -> Result<*const c_char, crate::sys::EspError>
     where
-        S: AsRef<str>,
+        S: Into<Vec<u8>>,
     {
         s.map(|s| self.as_ptr(s)).unwrap_or(Ok(core::ptr::null()))
     }
@@ -86,7 +86,10 @@ pub fn nul_to_invalid_arg(_err: alloc::ffi::NulError) -> crate::sys::EspError {
 }
 
 #[cfg(feature = "alloc")]
-pub fn to_cstring_arg(value: &str) -> Result<CString, crate::sys::EspError> {
+pub fn to_cstring_arg<S>(value: S) -> Result<CString, crate::sys::EspError>
+where
+    S: Into<Vec<u8>>,
+{
     CString::new(value).map_err(nul_to_invalid_arg)
 }
 

--- a/src/sntp.rs
+++ b/src/sntp.rs
@@ -267,7 +267,7 @@ impl<'a> EspSntp<'a> {
 
         let mut c_servers: [CString; SNTP_SERVER_NUM] = Default::default();
         for (i, s) in conf.servers.iter().enumerate() {
-            let c_server = to_cstring_arg(s)?;
+            let c_server = to_cstring_arg(*s)?;
             unsafe { sntp_setservername(i as u8, c_server.as_ptr()) };
             c_servers[i] = c_server;
         }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -528,6 +528,7 @@ impl<'d> WifiDriver<'d> {
             wifi_task_core_id: WIFI_TASK_CORE_ID as _,
             beacon_max_len: WIFI_SOFTAP_BEACON_MAX_LEN as _,
             mgmt_sbuf_num: WIFI_MGMT_SBUF_NUM as _,
+            #[cfg(esp_idf_version_major = "4")]
             feature_caps: unsafe { g_wifi_feature_caps },
             sta_disconnected_pm: WIFI_STA_DISCONNECTED_PM_ENABLED != 0,
             // Available since ESP IDF V4.4.4+

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -294,8 +294,8 @@ impl<'a> TryFrom<&'a EspWebSocketClientConfig<'a>> for (esp_websocket_client_con
 /// X509 takes a CStr, which must contain a null terminator, and X509.data() returns a &[u8]
 /// including that null.
 ///
-/// But RawCstrs.as_nptr() takes an Into<Vec<u8>> and gives it to CString::new(), whose argument
-/// cannot contain a null character.
+/// But RawCstrs.as_nptr() takes an Into<alloc::vec::Vec<u8>> and gives it to CString::new(),
+/// whose argument cannot contain a null character.
 ///
 /// So this function returns the subset of the slice without the terminator.
 fn x509_data<'a>(x509: &'a X509) -> &'a [u8] {

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -378,6 +378,11 @@ pub struct EspWebSocketClient<'a> {
     // `send` method in the `Sender` trait in embedded_svc::ws does not take a timeout itself
     timeout: TickType_t,
     _callback: Box<dyn FnMut(i32, *mut esp_websocket_event_data_t) + Send + 'a>,
+    // CStrings that are used in the websocket configuration.
+    // We pass references into esp_websocket_client_init() via esp_websocket_client_config_t
+    // and must hold onto the CStrings they reference until the connection is dropped.
+    #[allow(dead_code)]
+    cstrs: RawCstrs,
 }
 
 impl EspWebSocketClient<'static> {
@@ -494,6 +499,7 @@ impl<'a> EspWebSocketClient<'a> {
             handle,
             timeout: t.0,
             _callback: boxed_raw_callback,
+            cstrs,
         };
 
         esp!(unsafe {

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -568,6 +568,10 @@ impl<'a> EspWebSocketClient<'a> {
         Ok(())
     }
 
+    pub fn is_connected(&self) -> bool {
+        unsafe { esp_websocket_client_is_connected(self.handle) }
+    }
+
     extern "C" fn handle(
         event_handler_arg: *mut ffi::c_void,
         _event_base: esp_event_base_t,

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -112,6 +112,7 @@ impl WebSocketClosingReason {
 
 #[derive(Debug)]
 pub enum WebSocketEventType<'a> {
+    BeforeConnect,
     Connected,
     Disconnected,
     Close(Option<WebSocketClosingReason>),
@@ -165,6 +166,8 @@ impl<'a> WebSocketEventType<'a> {
                 }
             }
             esp_websocket_event_id_t_WEBSOCKET_EVENT_CLOSED => Ok(Self::Closed),
+            #[cfg(esp_idf_version_major = "5")]
+            esp_websocket_event_id_t_WEBSOCKET_EVENT_BEFORE_CONNECT => Ok(Self::BeforeConnect),
             _ => Err(EspError::from_infallible::<ESP_ERR_INVALID_ARG>().into()),
         }
     }


### PR DESCRIPTION
While developing an application that uses the EspWebSocketClient API, I ran into several bugs in the implementation. This branch includes fixes for them along with one minor enhancement and a websocket_client example that demonstrates how to use the API.

I've separated the changes into individual commits, except for the last one, which contains several fixes to enable and document building the websocket_client example with ESP-IDF 5.*. See the individual commit messages for detailed descriptions of each fix/enhancement. (If it'd be easier to review, I can also separate these changes into individual PRs.)
