### PR TITLE
fixes `*mut esp_netif_obj` not Sync compiler error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /target
 /Cargo.lock
 **/*.rs.bk
+/rust-toolchain.toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod espnow;
     esp_idf_eth_use_openeth
 ))]
 pub mod eth;
-#[cfg(all(feature = "alloc", esp_idf_comp_esp_event_enabled))]
+// #[cfg(all(feature = "alloc", esp_idf_comp_esp_event_enabled))]
 pub mod eventloop;
 pub mod hal;
 pub mod handle;

--- a/src/private/common.rs
+++ b/src/private/common.rs
@@ -1,4 +1,7 @@
-use core::cell::UnsafeCell;
+use core::{
+    cell::UnsafeCell,
+    ops::{Deref, DerefMut},
+};
 
 pub struct Newtype<T>(pub T);
 
@@ -6,3 +9,38 @@ pub struct UnsafeCellSendSync<T>(pub UnsafeCell<T>);
 
 unsafe impl<T> Send for UnsafeCellSendSync<T> {}
 unsafe impl<T> Sync for UnsafeCellSendSync<T> {}
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct SendSyncPtr<T>(*mut T);
+
+impl<T> SendSyncPtr<T> {
+    pub fn new(ptr: *mut T) -> Self {
+        Self(ptr)
+    }
+
+    pub fn as_ptr(&self) -> *const T {
+        self.0
+    }
+
+    pub fn as_mut_ptr(&self) -> *mut T {
+        self.0
+    }
+}
+
+unsafe impl<T> Send for SendSyncPtr<T> where T: Send {}
+unsafe impl<T> Sync for SendSyncPtr<T> where T: Sync {}
+
+impl<T> Deref for SendSyncPtr<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+
+impl<T> DerefMut for SendSyncPtr<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.0 }
+    }
+}

--- a/src/private/common.rs
+++ b/src/private/common.rs
@@ -15,8 +15,8 @@ unsafe impl<T> Sync for UnsafeCellSendSync<T> {}
 pub struct SendSyncPtr<T>(*mut T);
 
 impl<T> SendSyncPtr<T> {
-    pub fn new(ptr: *mut T) -> Self {
-        Self(ptr)
+    pub fn new(ptr: *const T) -> Self {
+        Self(ptr as *mut T)
     }
 
     pub fn as_ptr(&self) -> *const T {

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1846,12 +1846,12 @@ impl EspTypedEventDeserializer<WifiEvent> for WifiEvent {
                     let creds = &payload.ap_cred[i as usize];
 
                     let Ok(ssid) = from_cstr_fallible(&creds.ssid) else {
-                        log::warn!("Received a non-UTF-8 SSID via WPS");
+                        warn!("Received a non-UTF-8 SSID via WPS");
                         continue;
                     };
 
                     let Ok(passphrase) = from_cstr_fallible(&creds.passphrase) else {
-                        log::warn!("Received a non-UTF-8 passphrase via WPS");
+                        warn!("Received a non-UTF-8 passphrase via WPS");
                         continue;
                     };
 


### PR DESCRIPTION
Fixes #56 (again).
Implements a new type wrapper `SendSyncPtr` for arbitrary pointer types and `impl`s `Send` and `Sync` on that wrapper. This is just an assertion for the compiler and assumes that the underlying apis from the sdk are relatively thread safe.