### PR TITLE
remove 0 byte from nvs.get_str

### DIFF
--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -547,7 +547,7 @@ impl<T: NvsPartitionId> EspNvs<T> {
                 esp!(err)?;
 
                 Ok(Some(unsafe {
-                    core::str::from_utf8_unchecked(&(buf[..len]))
+                    core::str::from_utf8_unchecked(&(buf[..len - 1]))
                 }))
             }
         }


### PR DESCRIPTION
The get_str function of nvs includes a 0 byte at the end that should not be there in rust.

I discovered this when passing the returned string to wifi setup and getting an esp error.