### PR TITLE
add missing wifi event WIFI_EVENT_HOME_CHANNEL_CHANGE

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1824,6 +1824,7 @@ pub enum WifiEvent {
     FtmReport,
     ActionTxStatus,
     RocDone,
+    HomeChannelChange,
 }
 
 impl EspTypedEventSource for WifiEvent {
@@ -1915,6 +1916,8 @@ impl EspTypedEventDeserializer<WifiEvent> for WifiEvent {
             WifiEvent::StaBeaconTimeout
         } else if event_id == wifi_event_t_WIFI_EVENT_ROC_DONE {
             WifiEvent::RocDone
+        } else if event_id == wifi_event_t_WIFI_EVENT_HOME_CHANNEL_CHANGE {
+            WifiEvent::HomeChannelChange
         } else {
             panic!("Unknown event ID: {}", event_id);
         };


### PR DESCRIPTION
Hi,

Somehow this event was missing for me. It seems to be [here](https://github.com/espressif/esp-idf/blob/b3f7e2c8a4d354df8ef8558ea7caddc07283a57b/components/esp_wifi/include/esp_wifi_types.h#L906), and my home WIFI setup triggers it consistently with the basic connect example, so I need this patch to get around the panic.