### PR TITLE
Change payload of EspEventPostData from [u32] to [u8]

### DIFF
--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -204,7 +204,7 @@ impl<'a> EspEventPostData<'a> {
     pub unsafe fn new_raw(
         source: &'static ffi::CStr,
         event_id: Option<i32>,
-        payload: &'a [u32],
+        payload: &'a [u8],
     ) -> Self {
         Self {
             source,


### PR DESCRIPTION
I'm implementing variable-sized events (via `serde`+`postcard`). The output of `postcard` is a `heapless::Vec<u8>`, which is exceedingly difficult to fit into a `[u32]`.

Since I cannot see any reason why the payload of a variable-sized event has to be alined to 4-byte words, I propose changing that to `[u8]`.

I have tested this change with https://gitlab.com/IvanSanchez/solanera/-/commit/94a974b70f47d75a6123580041fe0780a4b8e411 and everything seems to work allright.