### PR TITLE
make cargo espflash work by adding a partition.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ $ MCU=esp32c3 cargo espflash flash --target riscv32imc-esp-espidf --example wifi
 | esp32c3| riscv32imc-esp-espidf |
 | esp32c6| riscv32imac-esp-espidf |
 | esp32h2 | riscv32imac-esp-espidf |
+| esp32p4 | riscv32imafc-esp-espidf |
 | esp32 | xtensa-esp32-espidf |
 | esp32s2 | xtensa-esp32s2-espidf |
-| esp32s3 | xtemsa-esp32s3-espidf |
+| esp32s3 | xtensa-esp32s3-espidf |
 
 
 ## Setting up a "Hello, world!" binary crate with ESP IDF

--- a/README.md
+++ b/README.md
@@ -24,15 +24,21 @@ Follow the [Prerequisites](https://github.com/esp-rs/esp-idf-template#prerequisi
 The examples could be built and flashed conveniently with [`cargo-espflash`](https://github.com/esp-rs/espflash/). To run e.g. `wifi` on an e.g. ESP32-C3:
 (Swap the Rust target and example name with the target corresponding for your ESP32 MCU and with the example you would like to build)
 
-with `cargo-espflash` V2+:
+with `cargo-espflash`:
 ```sh
-$ cargo espflash flash --target riscv32imc-esp-espidf --example wifi --monitor
+$ MCU=esp32c3 cargo espflash flash --target riscv32imc-esp-espidf --example wifi --monitor
 ```
 
-with older `cargo-espflash`:
-```sh
-$ cargo espflash --target riscv32imc-esp-espidf --example wifi --monitor /dev/ttyUSB0
-```
+| MCU | "--target" |
+| --- | ------ |
+| esp32c2 | riscv32imc-esp-espidf |
+| esp32c3| riscv32imc-esp-espidf |
+| esp32c6| riscv32imac-esp-espidf |
+| esp32h2 | riscv32imac-esp-espidf |
+| esp32 | xtensa-esp32-espidf |
+| esp32s2 | xtensa-esp32s2-espidf |
+| esp32s3 | xtemsa-esp32s3-espidf |
+
 
 ## Setting up a "Hello, world!" binary crate with ESP IDF
 

--- a/espflash.toml
+++ b/espflash.toml
@@ -1,0 +1,1 @@
+partition_table = "partitions.csv"

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,0 +1,5 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+# Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
+nvs,      data, nvs,     ,        0x6000,
+phy_init, data, phy,     ,        0x1000,
+factory,  app,  factory, ,        3M,


### PR DESCRIPTION
For running the examples we are using `cargo espflash`. By default `cargo espflash` will be using the partition.bin created inside esp-idf-sys ( `espflash` by default will use its own. The problem is that the default esp-idf-sys partition has only a 1MB big AppPartition size. All sdkconfig options for using different sized partitions only lead to a max AppPartition to 1.5MB and this is still to less for an wifi example with debug infos. So the simplest / cleanest solution is to simply provide one with the configuration file-