### PR TITLE
Support disabling SoftAP

### DIFF
--- a/examples/wifi_static_ip.rs
+++ b/examples/wifi_static_ip.rs
@@ -80,6 +80,7 @@ fn configure_wifi(wifi: WifiDriver) -> anyhow::Result<EspWifi> {
             )),
             ..NetifConfiguration::wifi_default_client()
         })?,
+        #[cfg(esp_idf_esp_wifi_softap_support)]
         EspNetif::new(NetifStack::Ap)?,
     )?;
 

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -26,7 +26,7 @@ use crate::private::mutex;
 pub enum NetifStack {
     /// Station mode (WiFi client)
     Sta,
-    #[cfg(esp_idf_softap_support)]
+    #[cfg(esp_idf_esp_wifi_softap_support)]
     /// Access point mode (WiFi router)
     Ap,
     /// Ethernet
@@ -43,7 +43,7 @@ impl NetifStack {
     pub fn default_configuration(&self) -> NetifConfiguration {
         match self {
             Self::Sta => NetifConfiguration::wifi_default_client(),
-            #[cfg(esp_idf_softap_support)]
+            #[cfg(esp_idf_esp_wifi_softap_support)]
             Self::Ap => NetifConfiguration::wifi_default_router(),
             Self::Eth => NetifConfiguration::eth_default_client(),
             #[cfg(esp_idf_lwip_ppp_support)]
@@ -67,7 +67,7 @@ impl NetifStack {
     fn default_mac_raw_type(&self) -> Option<esp_mac_type_t> {
         match self {
             Self::Sta => Some(esp_mac_type_t_ESP_MAC_WIFI_STA),
-            #[cfg(esp_idf_softap_support)]
+            #[cfg(esp_idf_esp_wifi_softap_support)]
             Self::Ap => Some(esp_mac_type_t_ESP_MAC_WIFI_SOFTAP),
             Self::Eth => Some(esp_mac_type_t_ESP_MAC_ETH),
             #[cfg(any(esp_idf_lwip_slip_support, esp_idf_lwip_ppp_support))]
@@ -79,7 +79,7 @@ impl NetifStack {
         unsafe {
             match self {
                 Self::Sta => _g_esp_netif_netstack_default_wifi_sta,
-                #[cfg(esp_idf_softap_support)]
+                #[cfg(esp_idf_esp_wifi_softap_support)]
                 Self::Ap => _g_esp_netif_netstack_default_wifi_ap,
                 Self::Eth => _g_esp_netif_netstack_default_eth,
                 #[cfg(esp_idf_lwip_ppp_support)]
@@ -135,7 +135,7 @@ impl NetifConfiguration {
         }
     }
 
-    #[cfg(esp_idf_softap_support)]
+    #[cfg(esp_idf_esp_wifi_softap_support)]
     pub fn wifi_default_router() -> Self {
         Self {
             key: "WIFI_AP_DEF".try_into().unwrap(),

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -26,6 +26,7 @@ use crate::private::mutex;
 pub enum NetifStack {
     /// Station mode (WiFi client)
     Sta,
+    #[cfg(esp_idf_softap_support)]
     /// Access point mode (WiFi router)
     Ap,
     /// Ethernet
@@ -42,6 +43,7 @@ impl NetifStack {
     pub fn default_configuration(&self) -> NetifConfiguration {
         match self {
             Self::Sta => NetifConfiguration::wifi_default_client(),
+            #[cfg(esp_idf_softap_support)]
             Self::Ap => NetifConfiguration::wifi_default_router(),
             Self::Eth => NetifConfiguration::eth_default_client(),
             #[cfg(esp_idf_lwip_ppp_support)]
@@ -65,6 +67,7 @@ impl NetifStack {
     fn default_mac_raw_type(&self) -> Option<esp_mac_type_t> {
         match self {
             Self::Sta => Some(esp_mac_type_t_ESP_MAC_WIFI_STA),
+            #[cfg(esp_idf_softap_support)]
             Self::Ap => Some(esp_mac_type_t_ESP_MAC_WIFI_SOFTAP),
             Self::Eth => Some(esp_mac_type_t_ESP_MAC_ETH),
             #[cfg(any(esp_idf_lwip_slip_support, esp_idf_lwip_ppp_support))]
@@ -76,6 +79,7 @@ impl NetifStack {
         unsafe {
             match self {
                 Self::Sta => _g_esp_netif_netstack_default_wifi_sta,
+                #[cfg(esp_idf_softap_support)]
                 Self::Ap => _g_esp_netif_netstack_default_wifi_ap,
                 Self::Eth => _g_esp_netif_netstack_default_eth,
                 #[cfg(esp_idf_lwip_ppp_support)]
@@ -131,6 +135,7 @@ impl NetifConfiguration {
         }
     }
 
+    #[cfg(esp_idf_softap_support)]
     pub fn wifi_default_router() -> Self {
         Self {
             key: "WIFI_AP_DEF".try_into().unwrap(),

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1559,7 +1559,7 @@ impl<'d> EspWifi<'d> {
             #[cfg(esp_idf_esp_wifi_softap_support)]
             let ok = ok && {
                 let ap_enabled = self.driver().is_ap_enabled()?;
-                (!ap_enabled || self.ap_netif().is_up()?)
+                !ap_enabled || self.ap_netif().is_up()?
             };
             Ok(ok)
         }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1407,7 +1407,7 @@ impl<'d> Wifi for WifiDriver<'d> {
 /// ESP IDF Wifi radio.
 #[cfg(esp_idf_comp_esp_netif_enabled)]
 pub struct EspWifi<'d> {
-    #[cfg(esp_idf_softap_support)]
+    #[cfg(esp_idf_esp_wifi_softap_support)]
     ap_netif: EspNetif,
     sta_netif: EspNetif,
     driver: WifiDriver<'d>,
@@ -1436,7 +1436,7 @@ impl<'d> EspWifi<'d> {
         Self::wrap_all(
             driver,
             EspNetif::new(NetifStack::Sta)?,
-            #[cfg(esp_idf_softap_support)]
+            #[cfg(esp_idf_esp_wifi_softap_support)]
             EspNetif::new(NetifStack::Ap)?,
         )
     }
@@ -1444,12 +1444,12 @@ impl<'d> EspWifi<'d> {
     pub fn wrap_all(
         driver: WifiDriver<'d>,
         sta_netif: EspNetif,
-        #[cfg(esp_idf_softap_support)] ap_netif: EspNetif,
+        #[cfg(esp_idf_esp_wifi_softap_support)] ap_netif: EspNetif,
     ) -> Result<Self, EspError> {
         let mut this = Self {
             driver,
             sta_netif,
-            #[cfg(esp_idf_softap_support)]
+            #[cfg(esp_idf_esp_wifi_softap_support)]
             ap_netif,
         };
 
@@ -1458,7 +1458,7 @@ impl<'d> EspWifi<'d> {
         Ok(this)
     }
 
-    #[cfg(esp_idf_softap_support)]
+    #[cfg(esp_idf_esp_wifi_softap_support)]
     /// Replaces the network interfaces with the given ones. Returns the old ones.
     pub fn swap_netif(
         &mut self,
@@ -1487,7 +1487,7 @@ impl<'d> EspWifi<'d> {
         Ok(old)
     }
 
-    #[cfg(esp_idf_softap_support)]
+    #[cfg(esp_idf_esp_wifi_softap_support)]
     /// Replaces the AP network interface with the provided one and returns the
     /// existing network interface.
     pub fn swap_netif_ap(&mut self, ap_netif: EspNetif) -> Result<EspNetif, EspError> {
@@ -1520,13 +1520,13 @@ impl<'d> EspWifi<'d> {
         &mut self.sta_netif
     }
 
-    #[cfg(esp_idf_softap_support)]
+    #[cfg(esp_idf_esp_wifi_softap_support)]
     /// Returns the underlying [`EspNetif`] for AP mode
     pub fn ap_netif(&self) -> &EspNetif {
         &self.ap_netif
     }
 
-    #[cfg(esp_idf_softap_support)]
+    #[cfg(esp_idf_esp_wifi_softap_support)]
     /// Returns the underlying [`EspNetif`] for AP mode, as mutable
     pub fn ap_netif_mut(&mut self) -> &mut EspNetif {
         &mut self.ap_netif
@@ -1556,7 +1556,7 @@ impl<'d> EspWifi<'d> {
             let sta_enabled = self.driver().is_sta_enabled()?;
             let ok = !sta_enabled || self.sta_netif().is_up()?;
 
-            #[cfg(esp_idf_softap_support)]
+            #[cfg(esp_idf_esp_wifi_softap_support)]
             let ok = ok && {
                 let ap_enabled = self.driver().is_ap_enabled()?;
                 (!ap_enabled || self.ap_netif().is_up()?)
@@ -1666,7 +1666,7 @@ impl<'d> EspWifi<'d> {
     fn attach_netif(&mut self) -> Result<(), EspError> {
         let _ = self.driver.stop();
 
-        #[cfg(esp_idf_softap_support)]
+        #[cfg(esp_idf_esp_wifi_softap_support)]
         {
             esp!(unsafe { esp_netif_attach_wifi_ap(self.ap_netif.handle()) })?;
             esp!(unsafe { esp_wifi_set_default_wifi_ap_handlers() })?;
@@ -1681,7 +1681,7 @@ impl<'d> EspWifi<'d> {
     fn detach_netif(&mut self) -> Result<(), EspError> {
         let _ = self.driver.stop();
 
-        #[cfg(esp_idf_softap_support)]
+        #[cfg(esp_idf_esp_wifi_softap_support)]
         esp!(unsafe {
             esp_wifi_clear_default_wifi_driver_and_handlers(
                 self.ap_netif.handle() as *mut ffi::c_void

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1407,6 +1407,7 @@ impl<'d> Wifi for WifiDriver<'d> {
 /// ESP IDF Wifi radio.
 #[cfg(esp_idf_comp_esp_netif_enabled)]
 pub struct EspWifi<'d> {
+    #[cfg(esp_idf_softap_support)]
     ap_netif: EspNetif,
     sta_netif: EspNetif,
     driver: WifiDriver<'d>,
@@ -1435,6 +1436,7 @@ impl<'d> EspWifi<'d> {
         Self::wrap_all(
             driver,
             EspNetif::new(NetifStack::Sta)?,
+            #[cfg(esp_idf_softap_support)]
             EspNetif::new(NetifStack::Ap)?,
         )
     }
@@ -1442,11 +1444,12 @@ impl<'d> EspWifi<'d> {
     pub fn wrap_all(
         driver: WifiDriver<'d>,
         sta_netif: EspNetif,
-        ap_netif: EspNetif,
+        #[cfg(esp_idf_softap_support)] ap_netif: EspNetif,
     ) -> Result<Self, EspError> {
         let mut this = Self {
             driver,
             sta_netif,
+            #[cfg(esp_idf_softap_support)]
             ap_netif,
         };
 
@@ -1455,6 +1458,7 @@ impl<'d> EspWifi<'d> {
         Ok(this)
     }
 
+    #[cfg(esp_idf_softap_support)]
     /// Replaces the network interfaces with the given ones. Returns the old ones.
     pub fn swap_netif(
         &mut self,
@@ -1483,6 +1487,7 @@ impl<'d> EspWifi<'d> {
         Ok(old)
     }
 
+    #[cfg(esp_idf_softap_support)]
     /// Replaces the AP network interface with the provided one and returns the
     /// existing network interface.
     pub fn swap_netif_ap(&mut self, ap_netif: EspNetif) -> Result<EspNetif, EspError> {
@@ -1515,11 +1520,13 @@ impl<'d> EspWifi<'d> {
         &mut self.sta_netif
     }
 
+    #[cfg(esp_idf_softap_support)]
     /// Returns the underlying [`EspNetif`] for AP mode
     pub fn ap_netif(&self) -> &EspNetif {
         &self.ap_netif
     }
 
+    #[cfg(esp_idf_softap_support)]
     /// Returns the underlying [`EspNetif`] for AP mode, as mutable
     pub fn ap_netif_mut(&mut self) -> &mut EspNetif {
         &mut self.ap_netif
@@ -1546,11 +1553,15 @@ impl<'d> EspWifi<'d> {
         if !self.driver().is_connected()? {
             Ok(false)
         } else {
-            let ap_enabled = self.driver().is_ap_enabled()?;
             let sta_enabled = self.driver().is_sta_enabled()?;
+            let ok = !sta_enabled || self.sta_netif().is_up()?;
 
-            Ok((!ap_enabled || self.ap_netif().is_up()?)
-                && (!sta_enabled || self.sta_netif().is_up()?))
+            #[cfg(esp_idf_softap_support)]
+            let ok = ok && {
+                let ap_enabled = self.driver().is_ap_enabled()?;
+                (!ap_enabled || self.ap_netif().is_up()?)
+            };
+            Ok(ok)
         }
     }
 
@@ -1655,8 +1666,11 @@ impl<'d> EspWifi<'d> {
     fn attach_netif(&mut self) -> Result<(), EspError> {
         let _ = self.driver.stop();
 
-        esp!(unsafe { esp_netif_attach_wifi_ap(self.ap_netif.handle()) })?;
-        esp!(unsafe { esp_wifi_set_default_wifi_ap_handlers() })?;
+        #[cfg(esp_idf_softap_support)]
+        {
+            esp!(unsafe { esp_netif_attach_wifi_ap(self.ap_netif.handle()) })?;
+            esp!(unsafe { esp_wifi_set_default_wifi_ap_handlers() })?;
+        }
 
         esp!(unsafe { esp_netif_attach_wifi_station(self.sta_netif.handle()) })?;
         esp!(unsafe { esp_wifi_set_default_wifi_sta_handlers() })?;
@@ -1667,6 +1681,7 @@ impl<'d> EspWifi<'d> {
     fn detach_netif(&mut self) -> Result<(), EspError> {
         let _ = self.driver.stop();
 
+        #[cfg(esp_idf_softap_support)]
         esp!(unsafe {
             esp_wifi_clear_default_wifi_driver_and_handlers(
                 self.ap_netif.handle() as *mut ffi::c_void


### PR DESCRIPTION
I think `wrap_all` itself should be gated by the `cfg` but wasn't sure if it was desirable or not