### PR TITLE
Fix WPS regression and cred conversion

### DIFF
--- a/src/private/cstr.rs
+++ b/src/private/cstr.rs
@@ -41,6 +41,14 @@ pub fn from_cstr(buf: &[u8]) -> &str {
     from_cstr_fallible(buf).unwrap()
 }
 
+pub fn array_to_heapless_string_failible<const N: usize>(arr: [u8; N]) -> heapless::String<N> {
+    heapless::String::from_utf8(heapless::Vec::from_slice(&arr).unwrap())
+}
+
+pub fn array_to_heapless_string<const N: usize>(arr: [u8; N]) -> heapless::String<N> {
+    array_to_heapless_string_failible(arr).unwrap()
+}
+
 #[cfg(feature = "alloc")]
 pub struct RawCstrs(alloc::vec::Vec<CString>);
 

--- a/src/private/cstr.rs
+++ b/src/private/cstr.rs
@@ -20,6 +20,19 @@ pub fn set_str(buf: &mut [u8], s: &str) -> Result<(), EspError> {
     Ok(())
 }
 
+pub fn set_str_no_termination_requirement(buf: &mut [u8], s: &str) -> Result<(), EspError> {
+    if s.len() > buf.len() {
+        return Err(EspError::from_infallible::<ESP_ERR_INVALID_SIZE>());
+    }
+
+    buf[..s.len()].copy_from_slice(s.as_bytes());
+    if buf.len() != s.len() {
+        buf[s.len()] = 0;
+    }
+
+    Ok(())
+}
+
 pub fn c_char_to_u8_slice_mut(s: &mut [c_char]) -> &mut [u8] {
     let s_ptr = unsafe { s.as_mut_ptr() as *mut u8 };
     unsafe { core::slice::from_raw_parts_mut(s_ptr, s.len()) }

--- a/src/private/cstr.rs
+++ b/src/private/cstr.rs
@@ -41,7 +41,9 @@ pub fn from_cstr(buf: &[u8]) -> &str {
     from_cstr_fallible(buf).unwrap()
 }
 
-pub fn array_to_heapless_string_failible<const N: usize>(arr: [u8; N]) -> heapless::String<N> {
+pub fn array_to_heapless_string_failible<const N: usize>(
+    arr: [u8; N],
+) -> Result<heapless::String<N>, Utf8Error> {
     heapless::String::from_utf8(heapless::Vec::from_slice(&arr).unwrap())
 }
 

--- a/src/private/cstr.rs
+++ b/src/private/cstr.rs
@@ -41,10 +41,13 @@ pub fn from_cstr(buf: &[u8]) -> &str {
     from_cstr_fallible(buf).unwrap()
 }
 
+/// Convert buffer of characters to heapless string, allowing either
+/// the full buffer (without terminating 0) or just a part of it (terminated by 0)
 pub fn array_to_heapless_string_failible<const N: usize>(
     arr: [u8; N],
 ) -> Result<heapless::String<N>, Utf8Error> {
-    heapless::String::from_utf8(heapless::Vec::from_slice(&arr).unwrap())
+    let len = arr.iter().position(|e| *e == 0).unwrap_or(N);
+    heapless::String::from_utf8(heapless::Vec::from_slice(&arr[0..len]).unwrap())
 }
 
 pub fn array_to_heapless_string<const N: usize>(arr: [u8; N]) -> heapless::String<N> {

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -2129,7 +2129,8 @@ impl<'a> EspEventDeserializer for WifiEvent<'a> {
                     .map(|x| &x.ap_cred[0..x.ap_cred_cnt as usize])
                     .unwrap_or(&[]);
                 // SAFETY: transparent representation of target type
-                let credentials: &[WpsCredentialsRef] = unsafe { std::mem::transmute(credentials) };
+                let credentials: &[WpsCredentialsRef] =
+                    unsafe { core::mem::transmute(credentials) };
 
                 WifiEvent::StaWpsSuccess(credentials)
             }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -275,7 +275,7 @@ impl From<Newtype<wifi_ap_config_t>> for AccessPointConfiguration {
     fn from(conf: Newtype<wifi_ap_config_t>) -> Self {
         Self {
             ssid: if conf.0.ssid_len == 0 {
-                from_cstr(&conf.0.ssid).try_into().unwrap()
+                Default::default()
             } else {
                 unsafe {
                     core::str::from_utf8_unchecked(&conf.0.ssid[0..conf.0.ssid_len as usize])
@@ -288,7 +288,7 @@ impl From<Newtype<wifi_ap_config_t>> for AccessPointConfiguration {
             secondary_channel: None,
             auth_method: Option::<AuthMethod>::from(Newtype(conf.0.authmode)).unwrap(),
             protocols: EnumSet::<Protocol>::empty(), // TODO
-            password: from_cstr(&conf.0.password).try_into().unwrap(),
+            password: array_to_heapless_string(conf.0.password),
             max_connections: conf.0.max_connection as u16,
         }
     }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -197,8 +197,8 @@ impl TryFrom<&ClientConfiguration> for Newtype<wifi_sta_config_t> {
             ..Default::default()
         };
 
-        set_str(&mut result.ssid, conf.ssid.as_ref())?;
-        set_str(&mut result.password, conf.password.as_ref())?;
+        set_str_no_termination_requirement(&mut result.ssid, conf.ssid.as_ref())?;
+        set_str_no_termination_requirement(&mut result.password, conf.password.as_ref())?;
 
         Ok(Newtype(result))
     }


### PR DESCRIPTION
Fixes #337
Also fixes the conversion of ssid/password in the config to no longer assume 0 termination - this lead to problems when routers send a 64 byte access token to us instead of a password