### PR TITLE
Reflect changes in embedded-svc wifi ClientConfiguration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,13 @@ enumset = { version = "1", default-features = false }
 log = { version = "0.4", default-features = false }
 uncased = { version = "0.9.7", default-features = false }
 embedded-hal-async = { version = "1", default-features = false }
-# embedded-svc = { version = "0.27", default-features = false }
-embedded-svc = { git = "https://github.com/embediver/embedded-svc.git", default-features = false }
+embedded-svc = { version = "0.27", default-features = false }
 esp-idf-hal = { version = "0.43", default-features = false }
 embassy-time-driver = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }
 embassy-futures = "0.1"
+
+[patch.crates-io]
+embedded-svc = { git = "https://github.com/embediver/embedded-svc.git" }
 
 [build-dependencies]
 embuild = "0.31.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ embassy-time-driver = { version = "0.1", optional = true, features = ["tick-hz-1
 embassy-futures = "0.1"
 
 [patch.crates-io]
-embedded-svc = { git = "https://github.com/embediver/embedded-svc.git" }
+embedded-svc = { git = "https://github.com/esp-rs/embedded-svc.git" }
 
 [build-dependencies]
 embuild = "0.31.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ enumset = { version = "1", default-features = false }
 log = { version = "0.4", default-features = false }
 uncased = { version = "0.9.7", default-features = false }
 embedded-hal-async = { version = "1", default-features = false }
-embedded-svc = { version = "0.27", default-features = false }
+# embedded-svc = { version = "0.27", default-features = false }
+embedded-svc = { git = "https://github.com/embediver/embedded-svc.git", default-features = false }
 esp-idf-hal = { version = "0.43", default-features = false }
 embassy-time-driver = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }
 embassy-futures = "0.1"

--- a/examples/http_client.rs
+++ b/examples/http_client.rs
@@ -173,6 +173,7 @@ fn connect_wifi(wifi: &mut BlockingWifi<EspWifi<'static>>) -> anyhow::Result<()>
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/http_ws_client.rs
+++ b/examples/http_ws_client.rs
@@ -136,6 +136,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             auth_method: AuthMethod::WPA2Personal,
             password: PASSWORD.try_into().unwrap(),
             channel: None,
+            ..Default::default()
         });
 
         wifi.set_configuration(&wifi_configuration)?;

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -104,6 +104,7 @@ fn connect_wifi(wifi: &mut BlockingWifi<EspWifi<'static>>) -> anyhow::Result<()>
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/wifi.rs
+++ b/examples/wifi.rs
@@ -49,6 +49,7 @@ fn connect_wifi(wifi: &mut BlockingWifi<EspWifi<'static>>) -> anyhow::Result<()>
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/wifi_async.rs
+++ b/examples/wifi_async.rs
@@ -53,6 +53,7 @@ async fn connect_wifi(wifi: &mut AsyncWifi<EspWifi<'static>>) -> anyhow::Result<
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/wifi_async_send.rs
+++ b/examples/wifi_async_send.rs
@@ -60,6 +60,7 @@ async fn connect_wifi() -> anyhow::Result<AsyncWifi<EspWifi<'static>>> {
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/wifi_static_ip.rs
+++ b/examples/wifi_static_ip.rs
@@ -89,6 +89,7 @@ fn configure_wifi(wifi: WifiDriver) -> anyhow::Result<EspWifi> {
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
     wifi.set_configuration(&wifi_configuration)?;
 

--- a/examples/wps.rs
+++ b/examples/wps.rs
@@ -49,6 +49,7 @@ fn main() -> anyhow::Result<()> {
                 auth_method: AuthMethod::WPA2Personal,
                 password: credentials[1].passphrase.clone(),
                 channel: None,
+                ..Default::default()
             });
             wifi.set_configuration(&wifi_configuration)?;
         }

--- a/examples/wps_async.rs
+++ b/examples/wps_async.rs
@@ -66,6 +66,7 @@ async fn connect_wps(wifi: &mut AsyncWifi<EspWifi<'static>>) -> anyhow::Result<(
                 auth_method: AuthMethod::WPA2Personal,
                 password: credentials[1].passphrase.clone(),
                 channel: None,
+                ..Default::default()
             });
             wifi.set_configuration(&wifi_configuration)?;
         }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -12,7 +12,7 @@ use ::log::*;
 
 use enumset::*;
 
-use embedded_svc::wifi::{PmfConfiguration, ScanMethod, ScanSortMethod, Wifi};
+use embedded_svc::wifi::Wifi;
 
 use crate::hal::modem::WifiModemPeripheral;
 use crate::hal::peripheral::Peripheral;
@@ -35,7 +35,7 @@ use crate::timer::EspTaskTimerService;
 
 pub use embedded_svc::wifi::{
     AccessPointConfiguration, AccessPointInfo, AuthMethod, Capability, ClientConfiguration,
-    Configuration, Protocol, SecondaryChannel,
+    Configuration, PmfConfiguration, Protocol, ScanMethod, ScanSortMethod, SecondaryChannel,
 };
 
 pub mod config {

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -12,7 +12,7 @@ use ::log::*;
 
 use enumset::*;
 
-use embedded_svc::wifi::Wifi;
+use embedded_svc::wifi::{PmfConfiguration, ScanMethod, ScanSortMethod, Wifi};
 
 use crate::hal::modem::WifiModemPeripheral;
 use crate::hal::peripheral::Peripheral;
@@ -168,12 +168,24 @@ impl TryFrom<&ClientConfiguration> for Newtype<wifi_sta_config_t> {
         let mut result = wifi_sta_config_t {
             ssid: [0; 32],
             password: [0; 64],
-            scan_method: wifi_scan_method_t_WIFI_ALL_CHANNEL_SCAN,
+            scan_method: match conf.scan_method {
+                ScanMethod::CompleteScan(_) => wifi_scan_method_t_WIFI_ALL_CHANNEL_SCAN,
+                ScanMethod::FastScan => wifi_scan_method_t_WIFI_FAST_SCAN,
+                _ => wifi_scan_method_t_WIFI_ALL_CHANNEL_SCAN,
+            },
             bssid_set: conf.bssid.is_some(),
             bssid,
             channel: conf.channel.unwrap_or(0u8),
             listen_interval: 0,
-            sort_method: wifi_sort_method_t_WIFI_CONNECT_AP_BY_SIGNAL,
+            sort_method: match conf.scan_method {
+                ScanMethod::CompleteScan(ScanSortMethod::Signal) => {
+                    wifi_sort_method_t_WIFI_CONNECT_AP_BY_SIGNAL
+                }
+                ScanMethod::CompleteScan(ScanSortMethod::Security) => {
+                    wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY
+                }
+                _ => wifi_sort_method_t_WIFI_CONNECT_AP_BY_SIGNAL,
+            },
             threshold: wifi_scan_threshold_t {
                 rssi: -127,
                 authmode: Newtype::<wifi_auth_mode_t>::from(conf.auth_method).0,
@@ -207,6 +219,30 @@ impl From<Newtype<wifi_sta_config_t>> for ClientConfiguration {
                 Some(conf.0.channel)
             } else {
                 None
+            },
+            #[allow(non_upper_case_globals)]
+            scan_method: match conf.0.scan_method {
+                wifi_scan_method_t_WIFI_FAST_SCAN => ScanMethod::FastScan,
+                wifi_scan_method_t_WIFI_ALL_CHANNEL_SCAN => match conf.0.sort_method {
+                    wifi_sort_method_t_WIFI_CONNECT_AP_BY_SIGNAL => {
+                        ScanMethod::CompleteScan(ScanSortMethod::Signal)
+                    }
+                    wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY => {
+                        ScanMethod::CompleteScan(ScanSortMethod::Security)
+                    }
+                    _ => ScanMethod::default(),
+                },
+                _ => ScanMethod::default(),
+            },
+            pmf_cfg: match conf.0.pmf_cfg {
+                wifi_pmf_config_t {
+                    capable: false,
+                    required: _,
+                } => PmfConfiguration::NotCapable,
+                wifi_pmf_config_t {
+                    capable: true,
+                    required,
+                } => PmfConfiguration::Capable { required },
             },
         }
     }


### PR DESCRIPTION
Reflect the changes to `ClientConfiguration` in `embedded-svc` which will be introduced by https://github.com/esp-rs/embedded-svc/pull/75.

Before marking it ready, https://github.com/esp-rs/embedded-svc/pull/75 has to be merged and the dependency to `embedded-svc` has to be changed back in `Cargo.toml`.