### PR TITLE
Fix: NVS encrypted partition name lookup

### DIFF
--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -157,15 +157,14 @@ impl NvsEncrypted {
             None
         };
 
-        let c_key_partition = c_key_partition
-            .map(|p| p.as_ptr())
-            .unwrap_or(core::ptr::null());
-
         let keys_partition_ptr = unsafe {
             esp_partition_find_first(
                 esp_partition_type_t_ESP_PARTITION_TYPE_DATA,
                 esp_partition_subtype_t_ESP_PARTITION_SUBTYPE_DATA_NVS_KEYS,
-                c_key_partition,
+                match c_key_partition {
+                    Some(ref v) => v.as_ptr(),
+                    None => core::ptr::null(),
+                },
             )
         };
 


### PR DESCRIPTION
The partition name is wrapped in an option, in the case the option has a value, the pointer to the underlying value is not valid when calling esp_partition_find_first. By keeping the reference valid while calling C, it remains valid.

Fixes https://github.com/esp-rs/esp-idf-svc/issues/384