### PR TITLE
ota: handle partition errors gracefully

### DIFF
--- a/src/ota.rs
+++ b/src/ota.rs
@@ -240,19 +240,28 @@ impl EspOta {
     }
 
     pub fn get_boot_slot(&self) -> Result<Slot, EspError> {
-        self.get_slot(unsafe { esp_ota_get_boot_partition().as_ref().unwrap() })
+        if let Some(partition) = unsafe { esp_ota_get_boot_partition().as_ref() } {
+            self.get_slot(partition)
+        } else {
+            Err(EspError::from_infallible::<ESP_ERR_NOT_FOUND>())
+        }
     }
 
     pub fn get_running_slot(&self) -> Result<Slot, EspError> {
-        self.get_slot(unsafe { esp_ota_get_running_partition().as_ref().unwrap() })
+        if let Some(partition) = unsafe { esp_ota_get_running_partition().as_ref() } {
+            self.get_slot(partition)
+        } else {
+            Err(EspError::from_infallible::<ESP_ERR_NOT_FOUND>())
+        }
     }
 
     pub fn get_update_slot(&self) -> Result<Slot, EspError> {
-        self.get_slot(unsafe {
-            esp_ota_get_next_update_partition(ptr::null())
-                .as_ref()
-                .unwrap()
-        })
+        if let Some(partition) = unsafe { esp_ota_get_next_update_partition(ptr::null()).as_ref() }
+        {
+            self.get_slot(partition)
+        } else {
+            Err(EspError::from_infallible::<ESP_ERR_NOT_FOUND>())
+        }
     }
 
     pub fn get_last_invalid_slot(&self) -> Result<Option<Slot>, EspError> {


### PR DESCRIPTION
When trying out the OTA functionality, my code was crashing when calling `get_boot_slot()` function. The function returns a Result, so crashing on error is rather counter-intuitive.

This PR adds graceful handling of calls `esp_ota_get_*_partition()` functions.