### PR TITLE
Add comment with HTTPS example

### DIFF
--- a/examples/http_client.rs
+++ b/examples/http_client.rs
@@ -37,7 +37,20 @@ fn main() -> anyhow::Result<()> {
 
     connect_wifi(&mut wifi)?;
 
-    // Create HTTP(S) client
+    // Create HTTP client
+    //
+    // Note: To send a request to an HTTPS server, you can do:
+    //
+    // ```
+    // use esp_idf_svc::http::client::{Configuration as HttpConfiguration, EspHttpConnection};
+    //
+    // let config = &HttpConfiguration {
+    //     crt_bundle_attach: Some(esp_idf_svc::sys::esp_crt_bundle_attach),
+    //     ..Default::default()
+    // };
+    //
+    // let mut client = HttpClient::wrap(EspHttpConnection::new(&config)?);
+    // ```
     let mut client = HttpClient::wrap(EspHttpConnection::new(&Default::default())?);
 
     // GET


### PR DESCRIPTION
This PR will hopefully prevent [this](https://github.com/esp-rs/esp-idf-svc/issues/389) from happening again.

At first, I thought about creating a separate `https_client.rs`, but that would create a lot of duplicate code (also it'd look strange if `http_client.rs` had an HTTPS version and `http_server.rs` didn't). I feel the comment will get the message across with no code duplication.

Note: There's aliasing here: 

    use esp_idf_svc::http::client::{Configuration as HttpConfiguration, EspHttpConnection};

To prevent conflict with this:

```
use embedded_svc::{
    // More imports
    wifi::{AuthMethod, ClientConfiguration, Configuration},
};
```