### PR TITLE
Flush responses to avoid repeated request failures

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -267,13 +267,6 @@ impl EspHttpConnection {
         Ok(())
     }
 
-    pub fn flush_response(&mut self) -> Result<(), EspError> {
-        let mut len = 0_i32;
-        esp!(unsafe { esp_http_client_flush_response(self.raw_client, &mut len) })?;
-
-        Ok(())
-    }
-
     pub fn is_request_initiated(&self) -> bool {
         self.state == State::Request
     }
@@ -365,6 +358,13 @@ impl EspHttpConnection {
         } else {
             Ok(())
         }
+    }
+
+    fn flush_response(&mut self) -> Result<(), EspError> {
+        let mut len = 0_i32;
+        esp!(unsafe { esp_http_client_flush_response(self.raw_client, &mut len) })?;
+
+        Ok(())
     }
 
     fn raw_write(&mut self, buf: &[u8]) -> Result<usize, EspError> {


### PR DESCRIPTION
Fixes #399.

I tested by using a loop that sends many HTTPS requests and by removing the part that reads and drains the data in the `http_client.rs` example. The pattern was the same: `ESP_FAIL` without `flush_response()`. No `ESP_FAIL` with `flush_response()`.

Some considerations:

1. Will flushing the response data in `initiate_request()` cause issues that cannot be observed in the `http_client.rs` example?
2. If the response data is [flushed](https://github.com/weiying-chen/esp-idf-svc/blob/feature/flush-response/src/http/client.rs#L213) in `initiate_request()`, will [flushing](https://github.com/weiying-chen/esp-idf-svc/blob/feature/flush-response/src/http/client.rs#L452) the response data in `fetch_headers()` be redundant?