### PR TITLE
clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ esp-idf-hal = { version = "0.43", default-features = false }
 embassy-time-driver = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }
 embassy-futures = "0.1"
 
+[patch.crates-io]
+embedded-svc = { git = "https://github.com/esp-rs/embedded-svc.git" }
+
 [build-dependencies]
 embuild = "0.31.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 links = "esp_idf_svc"
 build = "build.rs"
-documentation = "https://esp-rs.github.io/esp-idf-svc/"
+documentation = "https://docs.esp-rs.org/esp-idf-svc/"
 rust-version = "1.75"
 
 [features]

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -91,7 +91,7 @@ unsafe impl EspEventSource for CustomEvent {
 }
 
 impl EspEventSerializer for CustomEvent {
-    type Data<'a> = CustomEvent;
+    type Data<'a> = Self;
 
     fn serialize<F, R>(event: &Self::Data<'_>, f: F) -> R
     where
@@ -103,10 +103,10 @@ impl EspEventSerializer for CustomEvent {
 }
 
 impl EspEventDeserializer for CustomEvent {
-    type Data<'a> = CustomEvent;
+    type Data<'a> = Self;
 
     fn deserialize<'a>(data: &EspEvent<'a>) -> Self::Data<'a> {
         // Just as easy as serializing
-        *unsafe { data.as_payload::<CustomEvent>() }
+        *unsafe { data.as_payload::<Self>() }
     }
 }

--- a/examples/http_client.rs
+++ b/examples/http_client.rs
@@ -173,6 +173,7 @@ fn connect_wifi(wifi: &mut BlockingWifi<EspWifi<'static>>) -> anyhow::Result<()>
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/http_client.rs
+++ b/examples/http_client.rs
@@ -37,7 +37,20 @@ fn main() -> anyhow::Result<()> {
 
     connect_wifi(&mut wifi)?;
 
-    // Create HTTP(S) client
+    // Create HTTP client
+    //
+    // Note: To send a request to an HTTPS server, you can do:
+    //
+    // ```
+    // use esp_idf_svc::http::client::{Configuration as HttpConfiguration, EspHttpConnection};
+    //
+    // let config = &HttpConfiguration {
+    //     crt_bundle_attach: Some(esp_idf_svc::sys::esp_crt_bundle_attach),
+    //     ..Default::default()
+    // };
+    //
+    // let mut client = HttpClient::wrap(EspHttpConnection::new(&config)?);
+    // ```
     let mut client = HttpClient::wrap(EspHttpConnection::new(&Default::default())?);
 
     // GET

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -48,9 +48,7 @@ fn main() -> anyhow::Result<()> {
     let mut server = create_server()?;
 
     server.fn_handler("/", Method::Get, |req| {
-        req.into_ok_response()?
-            .write_all(INDEX_HTML.as_bytes())
-            .map(|_| ())
+        req.into_ok_response()?.write_all(INDEX_HTML.as_bytes())
     })?;
 
     server.fn_handler::<anyhow::Error, _>("/post", Method::Post, |mut req| {

--- a/examples/http_ws_client.rs
+++ b/examples/http_ws_client.rs
@@ -136,6 +136,7 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
             auth_method: AuthMethod::WPA2Personal,
             password: PASSWORD.try_into().unwrap(),
             channel: None,
+            ..Default::default()
         });
 
         wifi.set_configuration(&wifi_configuration)?;

--- a/examples/http_ws_server.rs
+++ b/examples/http_ws_server.rs
@@ -112,10 +112,10 @@ fn nth(n: u32) -> Cow<'static, str> {
             _ => unreachable!(),
         }),
         larger => Cow::Owned(match larger % 10 {
-            1 => format!("{}st", larger),
-            2 => format!("{}nd", larger),
-            3 => format!("{}rd", larger),
-            _ => format!("{}th", larger),
+            1 => format!("{larger}st"),
+            2 => format!("{larger}nd"),
+            3 => format!("{larger}rd"),
+            _ => format!("{larger}th"),
         }),
     }
 }
@@ -127,9 +127,7 @@ fn main() -> anyhow::Result<()> {
     let mut server = create_server()?;
 
     server.fn_handler("/", Method::Get, |req| {
-        req.into_ok_response()?
-            .write_all(INDEX_HTML.as_bytes())
-            .map(|_| ())
+        req.into_ok_response()?.write_all(INDEX_HTML.as_bytes())
     })?;
 
     let guessing_games = Mutex::new(BTreeMap::<i32, GuessingGame>::new());

--- a/examples/nvs_get_set_c_style.rs
+++ b/examples/nvs_get_set_c_style.rs
@@ -25,13 +25,13 @@ fn main() -> anyhow::Result<()> {
             info!("Got namespace {:?} from default partition", test_namespace);
             nvs
         }
-        Err(e) => panic!("Could't get namespace {:?}", e),
+        Err(e) => panic!("Could't get namespace {e:?}"),
     };
 
     let tag_u8 = "test_u8";
 
     match nvs.set_u8(tag_u8, 42) {
-        Ok(_) => info!("Tag updated"),
+        Ok(()) => info!("Tag updated"),
         // You can find the meaning of the error codes in the output of the error branch in:
         // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/error-codes.html
         Err(e) => info!("Tag not updated {:?}", e),
@@ -69,7 +69,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     match nvs.set_str(tag_test_str, "Hello from the NVS!") {
-        Ok(_) => info!("{:?} updated", tag_test_str),
+        Ok(()) => info!("{:?} updated", tag_test_str),
         Err(e) => info!("{:?} not updated {:?}", tag_test_str, e),
     };
 

--- a/examples/nvs_get_set_raw_storage.rs
+++ b/examples/nvs_get_set_raw_storage.rs
@@ -35,7 +35,7 @@ fn main() -> anyhow::Result<()> {
             info!("Got namespace {:?} from default partition", test_namespace);
             nvs
         }
-        Err(e) => panic!("Could't get namespace {:?}", e),
+        Err(e) => panic!("Could't get namespace {e:?}"),
     };
 
     let key_raw_u8 = "test_raw_u8";
@@ -115,7 +115,7 @@ fn main() -> anyhow::Result<()> {
                         "{:?} = {:?}",
                         key_raw_str,
                         from_bytes::<StructToBeStored>(the_struct)
-                    )
+                    );
                 }
             }
             Err(e) => info!("Couldn't get key {} because {:?}", key_raw_str, e),

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -104,6 +104,7 @@ fn connect_wifi(wifi: &mut BlockingWifi<EspWifi<'static>>) -> anyhow::Result<()>
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/tls_async.rs
+++ b/examples/tls_async.rs
@@ -177,11 +177,11 @@ pub mod example {
 
     impl esp_idf_svc::tls::Socket for EspTlsSocket {
         fn handle(&self) -> i32 {
-            EspTlsSocket::handle(self)
+            Self::handle(self)
         }
 
         fn release(&mut self) -> Result<(), esp_idf_svc::sys::EspError> {
-            EspTlsSocket::release(self)
+            Self::release(self)
         }
     }
 
@@ -190,14 +190,14 @@ pub mod example {
             &self,
             ctx: &mut core::task::Context,
         ) -> core::task::Poll<Result<(), esp_idf_svc::sys::EspError>> {
-            EspTlsSocket::poll_readable(self, ctx)
+            Self::poll_readable(self, ctx)
         }
 
         fn poll_writable(
             &self,
             ctx: &mut core::task::Context,
         ) -> core::task::Poll<Result<(), esp_idf_svc::sys::EspError>> {
-            EspTlsSocket::poll_writeable(self, ctx)
+            Self::poll_writeable(self, ctx)
         }
     }
 }

--- a/examples/wifi.rs
+++ b/examples/wifi.rs
@@ -49,6 +49,7 @@ fn connect_wifi(wifi: &mut BlockingWifi<EspWifi<'static>>) -> anyhow::Result<()>
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/wifi_async.rs
+++ b/examples/wifi_async.rs
@@ -53,6 +53,7 @@ async fn connect_wifi(wifi: &mut AsyncWifi<EspWifi<'static>>) -> anyhow::Result<
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/wifi_async_send.rs
+++ b/examples/wifi_async_send.rs
@@ -60,6 +60,7 @@ async fn connect_wifi() -> anyhow::Result<AsyncWifi<EspWifi<'static>>> {
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
 
     wifi.set_configuration(&wifi_configuration)?;

--- a/examples/wifi_static_ip.rs
+++ b/examples/wifi_static_ip.rs
@@ -89,6 +89,7 @@ fn configure_wifi(wifi: WifiDriver) -> anyhow::Result<EspWifi> {
         auth_method: AuthMethod::WPA2Personal,
         password: PASSWORD.try_into().unwrap(),
         channel: None,
+        ..Default::default()
     });
     wifi.set_configuration(&wifi_configuration)?;
 

--- a/examples/wps.rs
+++ b/examples/wps.rs
@@ -61,7 +61,7 @@ fn main() -> anyhow::Result<()> {
 
     match wifi.get_configuration()? {
         Configuration::Client(config) => {
-            info!("Successfully connected to {} using WPS", config.ssid)
+            info!("Successfully connected to {} using WPS", config.ssid);
         }
         _ => anyhow::bail!("Not in station mode"),
     };

--- a/examples/wps.rs
+++ b/examples/wps.rs
@@ -49,6 +49,7 @@ fn main() -> anyhow::Result<()> {
                 auth_method: AuthMethod::WPA2Personal,
                 password: credentials[1].passphrase.clone(),
                 channel: None,
+                ..Default::default()
             });
             wifi.set_configuration(&wifi_configuration)?;
         }

--- a/examples/wps_async.rs
+++ b/examples/wps_async.rs
@@ -66,6 +66,7 @@ async fn connect_wps(wifi: &mut AsyncWifi<EspWifi<'static>>) -> anyhow::Result<(
                 auth_method: AuthMethod::WPA2Personal,
                 password: credentials[1].passphrase.clone(),
                 channel: None,
+                ..Default::default()
             });
             wifi.set_configuration(&wifi_configuration)?;
         }

--- a/examples/wps_async.rs
+++ b/examples/wps_async.rs
@@ -78,7 +78,7 @@ async fn connect_wps(wifi: &mut AsyncWifi<EspWifi<'static>>) -> anyhow::Result<(
 
     match wifi.get_configuration()? {
         Configuration::Client(config) => {
-            info!("Successfully connected to {} using WPS", config.ssid)
+            info!("Successfully connected to {} using WPS", config.ssid);
         }
         _ => anyhow::bail!("Not in station mode"),
     };

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -757,8 +757,7 @@ impl<'d, T> EthDriver<'d, T> {
         len: u32,
         event_handler_arg: *mut ffi::c_void,
     ) -> esp_err_t {
-        UnsafeCallback::from_ptr(event_handler_arg as *mut _)
-            .call(EthFrame::new(buf, len));
+        UnsafeCallback::from_ptr(event_handler_arg as *mut _).call(EthFrame::new(buf, len));
 
         ESP_OK
     }

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::time::Duration;
-use core::{ffi, ptr, ops};
+use core::{ffi, ops, ptr};
 
 use ::log::*;
 

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -117,7 +117,7 @@ pub enum SpiEthChipset {
     KSZ8851SNL,
 }
 
-type RawCallback<'a> = Box<dyn FnMut(&[u8]) + Send + 'a>;
+type RawCallback<'a> = Box<dyn FnMut(EthFrame) + Send + 'a>;
 
 struct UnsafeCallback<'a>(*mut RawCallback<'a>);
 
@@ -135,7 +135,7 @@ impl<'a> UnsafeCallback<'a> {
         self.0.cast()
     }
 
-    unsafe fn call(&self, data: &[u8]) {
+    unsafe fn call(&self, data: EthFrame) {
         let reference = self.0.as_mut().unwrap();
 
         (reference)(data);
@@ -689,7 +689,7 @@ impl<'d, T> EthDriver<'d, T> {
 
     pub fn set_rx_callback<F>(&mut self, callback: F) -> Result<(), EspError>
     where
-        F: FnMut(&[u8]) + Send + 'static,
+        F: FnMut(EthFrame) + Send + 'static,
     {
         self.internal_set_rx_callback(callback)
     }
@@ -719,18 +719,18 @@ impl<'d, T> EthDriver<'d, T> {
     /// are introduced to Rust (i.e. the impossibility to "forget" a type and thus not call its destructor).
     pub unsafe fn set_nonstatic_rx_callback<F>(&mut self, callback: F) -> Result<(), EspError>
     where
-        F: FnMut(&[u8]) + Send + 'd,
+        F: FnMut(EthFrame) + Send + 'd,
     {
         self.internal_set_rx_callback(callback)
     }
 
-    fn internal_set_rx_callback<F>(&mut self, mut callback: F) -> Result<(), EspError>
+    fn internal_set_rx_callback<F>(&mut self, callback: F) -> Result<(), EspError>
     where
-        F: FnMut(&[u8]) + Send + 'd,
+        F: FnMut(EthFrame) + Send + 'd,
     {
         let _ = self.stop();
 
-        let mut callback: Box<RawCallback> = Box::new(Box::new(move |data| callback(data)));
+        let mut callback: Box<RawCallback> = Box::new(Box::new(callback));
 
         let unsafe_callback = UnsafeCallback::from(&mut callback);
 
@@ -758,7 +758,7 @@ impl<'d, T> EthDriver<'d, T> {
         event_handler_arg: *mut ffi::c_void,
     ) -> esp_err_t {
         UnsafeCallback::from_ptr(event_handler_arg as *mut _)
-            .call(core::slice::from_raw_parts(buf, len as _));
+            .call(EthFrame::new(buf, len));
 
         ESP_OK
     }
@@ -854,6 +854,33 @@ impl<'d, T> RawHandle for EthDriver<'d, T> {
 
     fn handle(&self) -> Self::Handle {
         self.handle
+    }
+}
+
+pub struct EthFrame {
+    buf: *mut u8,
+    len: u32,
+}
+
+unsafe impl Send for EthFrame {}
+
+impl EthFrame {
+    const unsafe fn new(buf: *mut u8, len: u32) -> Self {
+        Self { buf, len }
+    }
+
+    pub const fn as_slice(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.buf, self.len as _) }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { core::slice::from_raw_parts_mut(self.buf, self.len as _) }
+    }
+}
+
+impl Drop for EthFrame {
+    fn drop(&mut self) {
+        unsafe { free(self.buf.cast()) };
     }
 }
 

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -877,6 +877,20 @@ impl EthFrame {
     }
 }
 
+impl Deref for EthFrame {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.buf, self.len as _) }
+    }
+}
+
+impl DerefMut for EthFrame {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        unsafe { core::slice::from_raw_parts_mut(self.buf, self.len as _) }
+    }
+}
+
 impl Drop for EthFrame {
     fn drop(&mut self) {
         unsafe { free(self.buf.cast()) };

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::time::Duration;
-use core::{ffi, ptr};
+use core::{ffi, ptr, ops};
 
 use ::log::*;
 
@@ -877,7 +877,7 @@ impl EthFrame {
     }
 }
 
-impl Deref for EthFrame {
+impl ops::Deref for EthFrame {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
@@ -885,7 +885,7 @@ impl Deref for EthFrame {
     }
 }
 
-impl DerefMut for EthFrame {
+impl ops::DerefMut for EthFrame {
     fn deref_mut(&mut self) -> &mut [u8] {
         unsafe { core::slice::from_raw_parts_mut(self.buf, self.len as _) }
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -267,13 +267,6 @@ impl EspHttpConnection {
         Ok(())
     }
 
-    pub fn flush_response(&mut self) -> Result<(), EspError> {
-        let mut len = 0_i32;
-        esp!(unsafe { esp_http_client_flush_response(self.raw_client, &mut len) })?;
-
-        Ok(())
-    }
-
     pub fn is_request_initiated(&self) -> bool {
         self.state == State::Request
     }
@@ -365,6 +358,13 @@ impl EspHttpConnection {
         } else {
             Ok(())
         }
+    }
+
+    fn flush_response(&mut self) -> Result<(), EspError> {
+        let mut len = 0_i32;
+        esp!(unsafe { esp_http_client_flush_response(self.raw_client, &mut len) })?;
+
+        Ok(())
     }
 
     fn raw_write(&mut self, buf: &[u8]) -> Result<usize, EspError> {

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -157,15 +157,14 @@ impl NvsEncrypted {
             None
         };
 
-        let c_key_partition = c_key_partition
-            .map(|p| p.as_ptr())
-            .unwrap_or(core::ptr::null());
-
         let keys_partition_ptr = unsafe {
             esp_partition_find_first(
                 esp_partition_type_t_ESP_PARTITION_TYPE_DATA,
                 esp_partition_subtype_t_ESP_PARTITION_SUBTYPE_DATA_NVS_KEYS,
-                c_key_partition,
+                match c_key_partition {
+                    Some(ref v) => v.as_ptr(),
+                    None => core::ptr::null(),
+                },
             )
         };
 

--- a/src/ota.rs
+++ b/src/ota.rs
@@ -240,19 +240,28 @@ impl EspOta {
     }
 
     pub fn get_boot_slot(&self) -> Result<Slot, EspError> {
-        self.get_slot(unsafe { esp_ota_get_boot_partition().as_ref().unwrap() })
+        if let Some(partition) = unsafe { esp_ota_get_boot_partition().as_ref() } {
+            self.get_slot(partition)
+        } else {
+            Err(EspError::from_infallible::<ESP_ERR_NOT_FOUND>())
+        }
     }
 
     pub fn get_running_slot(&self) -> Result<Slot, EspError> {
-        self.get_slot(unsafe { esp_ota_get_running_partition().as_ref().unwrap() })
+        if let Some(partition) = unsafe { esp_ota_get_running_partition().as_ref() } {
+            self.get_slot(partition)
+        } else {
+            Err(EspError::from_infallible::<ESP_ERR_NOT_FOUND>())
+        }
     }
 
     pub fn get_update_slot(&self) -> Result<Slot, EspError> {
-        self.get_slot(unsafe {
-            esp_ota_get_next_update_partition(ptr::null())
-                .as_ref()
-                .unwrap()
-        })
+        if let Some(partition) = unsafe { esp_ota_get_next_update_partition(ptr::null()).as_ref() }
+        {
+            self.get_slot(partition)
+        } else {
+            Err(EspError::from_infallible::<ESP_ERR_NOT_FOUND>())
+        }
     }
 
     pub fn get_last_invalid_slot(&self) -> Result<Option<Slot>, EspError> {

--- a/src/private/mutex.rs
+++ b/src/private/mutex.rs
@@ -50,7 +50,7 @@ impl RawCondvar {
     pub fn new() -> Self {
         let mut cond: pthread_cond_t = Default::default();
 
-        let r = unsafe { pthread_cond_init(&mut cond as *mut _, ptr::null()) };
+        let r = unsafe { pthread_cond_init(ptr::addr_of_mut!(cond), ptr::null()) };
         debug_assert_eq!(r, 0);
 
         Self(UnsafeCell::new(cond))
@@ -72,7 +72,7 @@ impl RawCondvar {
             tv_nsec: (now.tv_usec * 1000) + duration.subsec_nanos() as i32,
         };
 
-        let r = pthread_cond_timedwait(self.0.get(), mutex.0.get(), &abstime as *const _);
+        let r = pthread_cond_timedwait(self.0.get(), mutex.0.get(), ptr::addr_of!(abstime));
         debug_assert!(r == ERR_ETIMEDOUT || r == 0);
 
         r == ERR_ETIMEDOUT

--- a/src/private/net.rs
+++ b/src/private/net.rs
@@ -9,12 +9,12 @@ impl From<ipv4::Ipv4Addr> for Newtype<esp_ip4_addr_t> {
     fn from(ip: ipv4::Ipv4Addr) -> Self {
         let octets = ip.octets();
 
-        let addr = ((octets[0] as u32 & 0xff) << 24)
-            | ((octets[1] as u32 & 0xff) << 16)
-            | ((octets[2] as u32 & 0xff) << 8)
-            | (octets[3] as u32 & 0xff);
+        let addr = ((u32::from(octets[0]) & 0xff) << 24)
+            | ((u32::from(octets[1]) & 0xff) << 16)
+            | ((u32::from(octets[2]) & 0xff) << 8)
+            | (u32::from(octets[3]) & 0xff);
 
-        Newtype(esp_ip4_addr_t {
+        Self(esp_ip4_addr_t {
             addr: u32::from_be(addr),
         })
     }
@@ -31,7 +31,7 @@ impl From<Newtype<esp_ip4_addr_t>> for ipv4::Ipv4Addr {
             (addr & 0xff) as u8,
         );
 
-        ipv4::Ipv4Addr::new(a, b, c, d)
+        Self::new(a, b, c, d)
     }
 }
 
@@ -39,7 +39,7 @@ impl From<ipv4::Ipv4Addr> for Newtype<ip4_addr_t> {
     fn from(ip: ipv4::Ipv4Addr) -> Self {
         let result: Newtype<esp_ip4_addr_t> = ip.into();
 
-        Newtype(ip4_addr_t {
+        Self(ip4_addr_t {
             addr: result.0.addr,
         })
     }
@@ -66,7 +66,7 @@ impl TryFrom<Newtype<esp_ip4_addr_t>> for Mask {
         let ip: ipv4::Ipv4Addr = esp_ip.into();
 
         ip.try_into()
-            .map_err(|_| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
+            .map_err(|()| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
     }
 }
 
@@ -85,13 +85,13 @@ impl TryFrom<Newtype<ip4_addr_t>> for Mask {
         let ip: ipv4::Ipv4Addr = esp_ip.into();
 
         ip.try_into()
-            .map_err(|_| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
+            .map_err(|()| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
     }
 }
 
 impl From<ipv4::IpInfo> for Newtype<esp_netif_ip_info_t> {
     fn from(ip_info: ipv4::IpInfo) -> Self {
-        Newtype(esp_netif_ip_info_t {
+        Self(esp_netif_ip_info_t {
             ip: Newtype::<esp_ip4_addr_t>::from(ip_info.ip).0,
             netmask: Newtype::<esp_ip4_addr_t>::from(ip_info.subnet.mask).0,
             gw: Newtype::<esp_ip4_addr_t>::from(ip_info.subnet.gateway).0,
@@ -101,7 +101,7 @@ impl From<ipv4::IpInfo> for Newtype<esp_netif_ip_info_t> {
 
 impl From<Newtype<esp_netif_ip_info_t>> for ipv4::IpInfo {
     fn from(ip_info: Newtype<esp_netif_ip_info_t>) -> Self {
-        ipv4::IpInfo {
+        Self {
             ip: ipv4::Ipv4Addr::from(Newtype(ip_info.0.ip)),
             subnet: ipv4::Subnet {
                 gateway: ipv4::Ipv4Addr::from(Newtype(ip_info.0.gw)),

--- a/src/private/stubs.rs
+++ b/src/private/stubs.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_const_for_fn)]
+
 use core::ffi;
 
 // TODO: Figure out which library references this

--- a/src/private/unblocker.rs
+++ b/src/private/unblocker.rs
@@ -48,7 +48,7 @@ where
                 Self::work,
                 task_name,
                 stack_size,
-                worker as *mut _,
+                worker.cast(),
                 priority.unwrap_or(6),
                 pin_to_core,
             )
@@ -73,8 +73,7 @@ where
     }
 
     extern "C" fn work(arg: *mut core::ffi::c_void) {
-        let worker: Box<Box<dyn FnOnce() + Send + 'static>> =
-            unsafe { Box::from_raw(arg as *mut _) };
+        let worker: Box<Box<dyn FnOnce() + Send + 'static>> = unsafe { Box::from_raw(arg.cast()) };
 
         worker();
     }

--- a/src/private/waitable.rs
+++ b/src/private/waitable.rs
@@ -48,7 +48,7 @@ where
         condition: F,
     ) -> Result<bool, EspError> {
         self.wait_timeout_while_and_get(dur, condition, |_| ())
-            .map(|(timeout, _)| timeout)
+            .map(|(timeout, ())| timeout)
     }
 
     pub fn wait_while_and_get<F: FnMut(&T) -> Result<bool, EspError>, G: FnMut(&T) -> Q, Q>(

--- a/src/private/zerocopy.rs
+++ b/src/private/zerocopy.rs
@@ -22,7 +22,7 @@ where
     T: Send + 'static,
 {
     pub fn get_shared(&mut self) -> Option<&mut T> {
-        if let Some(channel) = Weak::upgrade(&self.0) {
+        Weak::upgrade(&self.0).and_then(|channel| {
             let mut guard = channel.state.lock();
 
             loop {
@@ -32,9 +32,7 @@ where
                     State::Data(data) => break unsafe { data.as_mut() },
                 }
             }
-        } else {
-            None
-        }
+        })
     }
 
     pub async fn get_shared_async(&mut self) -> Option<&mut T> {

--- a/src/sntp.rs
+++ b/src/sntp.rs
@@ -22,8 +22,8 @@ mod esp_sntp {
         #[allow(non_upper_case_globals)]
         fn from(from: esp_sntp_operatingmode_t) -> Self {
             match from {
-                esp_sntp_operatingmode_t_ESP_SNTP_OPMODE_POLL => OperatingMode::Poll,
-                esp_sntp_operatingmode_t_ESP_SNTP_OPMODE_LISTENONLY => OperatingMode::ListenOnly,
+                esp_sntp_operatingmode_t_ESP_SNTP_OPMODE_POLL => Self::Poll,
+                esp_sntp_operatingmode_t_ESP_SNTP_OPMODE_LISTENONLY => Self::ListenOnly,
                 _ => unreachable!(),
             }
         }
@@ -99,8 +99,8 @@ impl From<sntp_sync_mode_t> for SyncMode {
     #[allow(non_upper_case_globals)]
     fn from(from: sntp_sync_mode_t) -> Self {
         match from {
-            sntp_sync_mode_t_SNTP_SYNC_MODE_SMOOTH => SyncMode::Smooth,
-            sntp_sync_mode_t_SNTP_SYNC_MODE_IMMED => SyncMode::Immediate,
+            sntp_sync_mode_t_SNTP_SYNC_MODE_SMOOTH => Self::Smooth,
+            sntp_sync_mode_t_SNTP_SYNC_MODE_IMMED => Self::Immediate,
             _ => unreachable!(),
         }
     }
@@ -127,9 +127,9 @@ impl From<sntp_sync_status_t> for SyncStatus {
     #[allow(non_upper_case_globals)]
     fn from(from: sntp_sync_status_t) -> Self {
         match from {
-            sntp_sync_status_t_SNTP_SYNC_STATUS_RESET => SyncStatus::Reset,
-            sntp_sync_status_t_SNTP_SYNC_STATUS_COMPLETED => SyncStatus::Completed,
-            sntp_sync_status_t_SNTP_SYNC_STATUS_IN_PROGRESS => SyncStatus::InProgress,
+            sntp_sync_status_t_SNTP_SYNC_STATUS_RESET => Self::Reset,
+            sntp_sync_status_t_SNTP_SYNC_STATUS_COMPLETED => Self::Completed,
+            sntp_sync_status_t_SNTP_SYNC_STATUS_IN_PROGRESS => Self::InProgress,
             _ => unreachable!(),
         }
     }
@@ -170,7 +170,7 @@ pub struct EspSntp<'a> {
 
 impl EspSntp<'static> {
     pub fn new_default() -> Result<Self, EspError> {
-        Self::new(&Default::default())
+        Self::new(&SntpConf::default())
     }
 
     pub fn new(conf: &SntpConf) -> Result<Self, EspError> {

--- a/src/systime.rs
+++ b/src/systime.rs
@@ -12,12 +12,12 @@ pub struct EspSystemTime;
 impl EspSystemTime {
     /// Return the current system time
     pub fn now(&self) -> Duration {
-        let mut tv_now: timeval = Default::default();
+        let mut tv_now = timeval::default();
 
         unsafe {
-            gettimeofday(&mut tv_now as *mut _, core::ptr::null_mut());
+            gettimeofday(core::ptr::addr_of_mut!(tv_now), core::ptr::null_mut());
         }
 
-        Duration::from_micros(tv_now.tv_sec as u64 * 1000000_u64 + tv_now.tv_usec as u64)
+        Duration::from_micros(tv_now.tv_sec as u64 * 1_000_000_u64 + tv_now.tv_usec as u64)
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -120,6 +120,8 @@ impl<'a> Debug for X509<'a> {
     any(esp_idf_esp_tls_using_mbedtls, esp_idf_esp_tls_using_wolfssl)
 ))]
 mod esptls {
+    #[cfg(esp_idf_esp_tls_server_cert_select_hook)]
+    use core::ffi::c_int;
     use core::task::{Context, Poll};
     use core::time::Duration;
 
@@ -300,8 +302,90 @@ mod esptls {
         pub hint: &'a CStr,
     }
 
+    #[cfg(esp_idf_esp_tls_server)]
+    pub struct ServerConfig<'a> {
+        /// up to 9 ALPNs allowed, with avg 10 bytes for each name
+        pub alpn_protos: Option<&'a [&'a str]>,
+        pub ca_cert: Option<X509<'a>>,
+        pub server_cert: Option<X509<'a>>,
+        pub server_key: Option<X509<'a>>,
+        pub server_key_password: Option<&'a str>,
+        pub use_secure_element: bool,
+        #[cfg(esp_idf_esp_tls_server_cert_select_hook)]
+        pub handshake_callback: Option<extern "C" fn(*mut sys::mbedtls_ssl_context) -> c_int>,
+    }
+
+    #[cfg(esp_idf_esp_tls_server)]
+    impl<'a> ServerConfig<'a> {
+        pub const fn new() -> Self {
+            Self {
+                alpn_protos: None,
+                ca_cert: None,
+                server_cert: None,
+                server_key: None,
+                server_key_password: None,
+                use_secure_element: false,
+                #[cfg(esp_idf_esp_tls_server_cert_select_hook)]
+                handshake_callback: None,
+            }
+        }
+
+        fn try_into_raw(
+            &self,
+            bufs: &mut RawConfigBufs,
+        ) -> Result<sys::esp_tls_cfg_server, EspError> {
+            let mut rcfg: sys::esp_tls_cfg_server = Default::default();
+
+            if let Some(ca_cert) = self.ca_cert {
+                rcfg.__bindgen_anon_1.cacert_buf = ca_cert.data().as_ptr();
+                rcfg.__bindgen_anon_2.cacert_bytes = ca_cert.data().len() as u32;
+            }
+
+            if let Some(server_cert) = self.server_cert {
+                rcfg.__bindgen_anon_3.servercert_buf = server_cert.data().as_ptr();
+                rcfg.__bindgen_anon_4.servercert_bytes = server_cert.data().len() as u32;
+            }
+
+            if let Some(server_key) = self.server_key {
+                rcfg.__bindgen_anon_5.serverkey_buf = server_key.data().as_ptr();
+                rcfg.__bindgen_anon_6.serverkey_bytes = server_key.data().len() as u32;
+            }
+
+            if let Some(ckp) = self.server_key_password {
+                rcfg.serverkey_password = ckp.as_ptr();
+                rcfg.serverkey_password_len = ckp.len() as u32;
+            }
+
+            // allow up to 9 protocols
+            if let Some(protos) = self.alpn_protos {
+                bufs.alpn_protos = cstr_arr_from_str_slice(protos, &mut bufs.alpn_protos_cbuf)?;
+                rcfg.alpn_protos = bufs.alpn_protos.as_mut_ptr();
+            }
+
+            rcfg.use_secure_element = self.use_secure_element;
+
+            #[cfg(esp_idf_esp_tls_server_cert_select_hook)]
+            if let Some(cb) = self.handshake_callback {
+                rcfg.cert_select_cb = cb;
+            }
+
+            Ok(rcfg)
+        }
+    }
+
+    #[cfg(esp_idf_esp_tls_server)]
+    impl<'a> Default for ServerConfig<'a> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     pub trait Socket {
+        /// Returns the integer FD.
         fn handle(&self) -> i32;
+        /// This is called before cleaning up the the tls context and is responsible
+        /// for essentially giving up ownership of the socket such that it can safely
+        /// be closed by the ESP IDF.
         fn release(&mut self) -> Result<(), EspError>;
     }
 
@@ -329,6 +413,8 @@ mod esptls {
     {
         raw: *mut sys::esp_tls,
         socket: S,
+        #[cfg(esp_idf_esp_tls_server)]
+        server_session: bool,
     }
 
     impl EspTls<InternalSocket> {
@@ -343,6 +429,8 @@ mod esptls {
                 Ok(Self {
                     raw,
                     socket: InternalSocket(()),
+                    #[cfg(esp_idf_esp_tls_server)]
+                    server_session: false,
                 })
             } else {
                 Err(EspError::from_infallible::<ESP_ERR_NO_MEM>())
@@ -395,7 +483,12 @@ mod esptls {
                     sys::esp_tls_set_conn_state(raw, sys::esp_tls_conn_state_ESP_TLS_CONNECTING)
                 })?;
 
-                Ok(Self { raw, socket })
+                Ok(Self {
+                    raw,
+                    socket,
+                    #[cfg(esp_idf_esp_tls_server)]
+                    server_session: false,
+                })
             } else {
                 Err(EspError::from_infallible::<ESP_ERR_NO_MEM>())
             }
@@ -425,6 +518,33 @@ mod esptls {
             drop(bufs);
 
             res
+        }
+
+        /// Establish a TLS/SSL connection using the adopted connection, acting as the server.
+        ///
+        /// # Errors
+        ///
+        /// * `ESP_FAIL` if connection could not be established
+        #[cfg(esp_idf_esp_tls_server)]
+        pub fn negotiate_server(&mut self, cfg: &ServerConfig) -> Result<(), EspError> {
+            let mut bufs = RawConfigBufs::default();
+            let mut rcfg = cfg.try_into_raw(&mut bufs)?;
+
+            unsafe {
+                let error =
+                    sys::esp_tls_server_session_create(&mut rcfg, self.socket.handle(), self.raw);
+                if error != 0 {
+                    log::error!("failed to create tls server session (error {error})");
+                    return Err(EspError::from_infallible::<ESP_FAIL>());
+                }
+            }
+            self.server_session = true;
+
+            // Make sure buffers are held long enough
+            #[allow(clippy::drop_non_drop)]
+            drop(bufs);
+
+            Ok(())
         }
 
         #[allow(clippy::unnecessary_cast)]
@@ -551,6 +671,10 @@ mod esptls {
 
             unsafe { sys::esp_tls_conn_write(self.raw, buf.as_ptr() as *const c_void, buf.len()) }
         }
+
+        pub fn context_handle(&self) -> *mut sys::esp_tls {
+            self.raw
+        }
     }
 
     impl<S> Drop for EspTls<S>
@@ -561,6 +685,7 @@ mod esptls {
             let _ = self.socket.release();
 
             unsafe {
+                // use esp_tls_conn_destroy for both client and server
                 sys::esp_tls_conn_destroy(self.raw);
             }
         }
@@ -667,6 +792,19 @@ mod esptls {
             res
         }
 
+        // TODO: Create upstream support for async server negotiation
+        // Establish a TLS/SSL connection using the adopted connection, acting as the server.
+        //
+        // # Errors
+        //
+        // * `ESP_FAIL` if connection could not be established
+        // #[cfg(esp_idf_esp_tls_server)]
+        // pub async fn negotiate_server(&mut self, cfg: &ServerConfig<'_>) -> Result<(), EspError> {
+        //     // FIXME: this isn't actually async, but esp-idf does not expose anything else.
+        //     // we would have to use various hacks to call mbedtls_ssl_handshake by ourself
+        //     self.0.borrow_mut().negotiate_server(cfg)
+        // }
+
         /// Read in the supplied buffer. Returns the number of bytes read.
         pub async fn read(&self, buf: &mut [u8]) -> Result<usize, EspError> {
             loop {
@@ -730,6 +868,10 @@ mod esptls {
             }
 
             Ok(())
+        }
+
+        pub fn context_handle(&self) -> *mut sys::esp_tls {
+            self.0.borrow().context_handle()
         }
     }
 

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -2,7 +2,7 @@
 use core::marker::PhantomData;
 use core::str::Utf8Error;
 use core::time::Duration;
-use core::{cmp, ffi, fmt};
+use core::{cmp, ffi, fmt, ops};
 
 extern crate alloc;
 use alloc::boxed::Box;
@@ -1409,6 +1409,20 @@ impl WifiFrame {
     }
 
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { core::slice::from_raw_parts_mut(self.buf, self.len as _) }
+    }
+}
+
+impl ops::Deref for WifiFrame {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.buf, self.len as _) }
+    }
+}
+
+impl ops::DerefMut for WifiFrame {
+    fn deref_mut(&mut self) -> &mut [u8] {
         unsafe { core::slice::from_raw_parts_mut(self.buf, self.len as _) }
     }
 }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1272,10 +1272,7 @@ impl<'d> WifiDriver<'d> {
         len: u16,
         eb: *mut ffi::c_void,
     ) -> esp_err_t {
-        let res = RX_CALLBACK.as_mut().unwrap()(
-            device_id,
-            WifiFrame::new(buf.cast(), len, eb),
-        );
+        let res = RX_CALLBACK.as_mut().unwrap()(device_id, WifiFrame::new(buf.cast(), len, eb));
 
         match res {
             Ok(_) => ESP_OK,

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -192,6 +192,8 @@ pub struct EspWebSocketClientConfig<'a> {
     pub disable_pingpong_discon: bool,
     pub use_global_ca_store: bool,
     pub skip_cert_common_name_check: bool,
+    #[cfg(not(esp_idf_version_major = "4"))]
+    pub crt_bundle_attach: Option<unsafe extern "C" fn(conf: *mut ffi::c_void) -> esp_err_t>,
     pub keep_alive_idle: Option<time::Duration>,
     pub keep_alive_interval: Option<time::Duration>,
     pub keep_alive_count: Option<u16>,
@@ -233,6 +235,8 @@ impl<'a> TryFrom<&'a EspWebSocketClientConfig<'a>> for (esp_websocket_client_con
 
             use_global_ca_store: conf.use_global_ca_store,
             skip_cert_common_name_check: conf.skip_cert_common_name_check,
+            #[cfg(not(esp_idf_version_major = "4"))]
+            crt_bundle_attach: conf.crt_bundle_attach,
 
             ping_interval_sec: conf.ping_interval_sec.as_secs() as _,
 


### PR DESCRIPTION
Many many lints. Notably:
- Remove unneeded `Result` wrapping some function return types.
- `if ... { panic! }` to `assert!`
- Replaced `if let` with `map_or` and similar.
- [Make `fn` `const` if possible.](https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn)
- [`ptr::addr_of!` instead of `&T as *const T` ](https://rust-lang.github.io/rust-clippy/master/index.html#borrow_as_ptr)
- [`.cast() instead of `*const T as *const U`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_as_ptr)
- [`.cast_mut()` instead of `*const T as *mut T`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_cast_constness)
- [`U::from(T)` instead of `T as U`](https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless)
- `"{}". foo` -> `"{foo}"`
- [Use `Self`](https://rust-lang.github.io/rust-clippy/master/index.html#use_self)
- ...

As many of these are subjective, feel free to modify/request modifications.