### PR TITLE
clippy lints

### DIFF
--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -91,7 +91,7 @@ unsafe impl EspEventSource for CustomEvent {
 }
 
 impl EspEventSerializer for CustomEvent {
-    type Data<'a> = CustomEvent;
+    type Data<'a> = Self;
 
     fn serialize<F, R>(event: &Self::Data<'_>, f: F) -> R
     where
@@ -103,10 +103,10 @@ impl EspEventSerializer for CustomEvent {
 }
 
 impl EspEventDeserializer for CustomEvent {
-    type Data<'a> = CustomEvent;
+    type Data<'a> = Self;
 
     fn deserialize<'a>(data: &EspEvent<'a>) -> Self::Data<'a> {
         // Just as easy as serializing
-        *unsafe { data.as_payload::<CustomEvent>() }
+        *unsafe { data.as_payload::<Self>() }
     }
 }

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -48,9 +48,7 @@ fn main() -> anyhow::Result<()> {
     let mut server = create_server()?;
 
     server.fn_handler("/", Method::Get, |req| {
-        req.into_ok_response()?
-            .write_all(INDEX_HTML.as_bytes())
-            .map(|_| ())
+        req.into_ok_response()?.write_all(INDEX_HTML.as_bytes())
     })?;
 
     server.fn_handler::<anyhow::Error, _>("/post", Method::Post, |mut req| {

--- a/examples/http_ws_server.rs
+++ b/examples/http_ws_server.rs
@@ -112,10 +112,10 @@ fn nth(n: u32) -> Cow<'static, str> {
             _ => unreachable!(),
         }),
         larger => Cow::Owned(match larger % 10 {
-            1 => format!("{}st", larger),
-            2 => format!("{}nd", larger),
-            3 => format!("{}rd", larger),
-            _ => format!("{}th", larger),
+            1 => format!("{larger}st"),
+            2 => format!("{larger}nd"),
+            3 => format!("{larger}rd"),
+            _ => format!("{larger}th"),
         }),
     }
 }
@@ -127,9 +127,7 @@ fn main() -> anyhow::Result<()> {
     let mut server = create_server()?;
 
     server.fn_handler("/", Method::Get, |req| {
-        req.into_ok_response()?
-            .write_all(INDEX_HTML.as_bytes())
-            .map(|_| ())
+        req.into_ok_response()?.write_all(INDEX_HTML.as_bytes())
     })?;
 
     let guessing_games = Mutex::new(BTreeMap::<i32, GuessingGame>::new());

--- a/examples/nvs_get_set_c_style.rs
+++ b/examples/nvs_get_set_c_style.rs
@@ -25,13 +25,13 @@ fn main() -> anyhow::Result<()> {
             info!("Got namespace {:?} from default partition", test_namespace);
             nvs
         }
-        Err(e) => panic!("Could't get namespace {:?}", e),
+        Err(e) => panic!("Could't get namespace {e:?}"),
     };
 
     let tag_u8 = "test_u8";
 
     match nvs.set_u8(tag_u8, 42) {
-        Ok(_) => info!("Tag updated"),
+        Ok(()) => info!("Tag updated"),
         // You can find the meaning of the error codes in the output of the error branch in:
         // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/error-codes.html
         Err(e) => info!("Tag not updated {:?}", e),
@@ -69,7 +69,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     match nvs.set_str(tag_test_str, "Hello from the NVS!") {
-        Ok(_) => info!("{:?} updated", tag_test_str),
+        Ok(()) => info!("{:?} updated", tag_test_str),
         Err(e) => info!("{:?} not updated {:?}", tag_test_str, e),
     };
 

--- a/examples/nvs_get_set_raw_storage.rs
+++ b/examples/nvs_get_set_raw_storage.rs
@@ -35,7 +35,7 @@ fn main() -> anyhow::Result<()> {
             info!("Got namespace {:?} from default partition", test_namespace);
             nvs
         }
-        Err(e) => panic!("Could't get namespace {:?}", e),
+        Err(e) => panic!("Could't get namespace {e:?}"),
     };
 
     let key_raw_u8 = "test_raw_u8";
@@ -115,7 +115,7 @@ fn main() -> anyhow::Result<()> {
                         "{:?} = {:?}",
                         key_raw_str,
                         from_bytes::<StructToBeStored>(the_struct)
-                    )
+                    );
                 }
             }
             Err(e) => info!("Couldn't get key {} because {:?}", key_raw_str, e),

--- a/examples/tls_async.rs
+++ b/examples/tls_async.rs
@@ -177,11 +177,11 @@ pub mod example {
 
     impl esp_idf_svc::tls::Socket for EspTlsSocket {
         fn handle(&self) -> i32 {
-            EspTlsSocket::handle(self)
+            Self::handle(self)
         }
 
         fn release(&mut self) -> Result<(), esp_idf_svc::sys::EspError> {
-            EspTlsSocket::release(self)
+            Self::release(self)
         }
     }
 
@@ -190,14 +190,14 @@ pub mod example {
             &self,
             ctx: &mut core::task::Context,
         ) -> core::task::Poll<Result<(), esp_idf_svc::sys::EspError>> {
-            EspTlsSocket::poll_readable(self, ctx)
+            Self::poll_readable(self, ctx)
         }
 
         fn poll_writable(
             &self,
             ctx: &mut core::task::Context,
         ) -> core::task::Poll<Result<(), esp_idf_svc::sys::EspError>> {
-            EspTlsSocket::poll_writeable(self, ctx)
+            Self::poll_writeable(self, ctx)
         }
     }
 }

--- a/examples/wps.rs
+++ b/examples/wps.rs
@@ -61,7 +61,7 @@ fn main() -> anyhow::Result<()> {
 
     match wifi.get_configuration()? {
         Configuration::Client(config) => {
-            info!("Successfully connected to {} using WPS", config.ssid)
+            info!("Successfully connected to {} using WPS", config.ssid);
         }
         _ => anyhow::bail!("Not in station mode"),
     };

--- a/examples/wps_async.rs
+++ b/examples/wps_async.rs
@@ -78,7 +78,7 @@ async fn connect_wps(wifi: &mut AsyncWifi<EspWifi<'static>>) -> anyhow::Result<(
 
     match wifi.get_configuration()? {
         Configuration::Client(config) => {
-            info!("Successfully connected to {} using WPS", config.ssid)
+            info!("Successfully connected to {} using WPS", config.ssid);
         }
         _ => anyhow::bail!("Not in station mode"),
     };

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -451,7 +451,7 @@ where
 
                 #[cfg(esp_idf_version_major = "4")]
                 let dm9051_cfg = eth_dm9051_config_t {
-                    spi_hdl: spi_handle.unwrap().cast_mut(),
+                    spi_hdl: spi_handle.unwrap().cast(),
                     int_gpio_num: int,
                 };
 
@@ -487,7 +487,7 @@ where
 
                 #[cfg(esp_idf_version_major = "4")]
                 let w5500_cfg = eth_w5500_config_t {
-                    spi_hdl: spi_handle.unwrap().cast_mut(),
+                    spi_hdl: spi_handle.unwrap().cast(),
                     int_gpio_num: int,
                 };
 
@@ -523,7 +523,7 @@ where
 
                 #[cfg(esp_idf_version_major = "4")]
                 let ksz8851snl_cfg = eth_ksz8851snl_config_t {
-                    spi_hdl: spi_handle.unwrap().cast_mut(),
+                    spi_hdl: spi_handle.unwrap().cast(),
                     int_gpio_num: int,
                 };
 

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -685,11 +685,11 @@ impl<'d, T> EthDriver<'d, T> {
         Ok(())
     }
 
-    pub fn set_rx_callback<F>(&mut self, callback: F)
+    pub fn set_rx_callback<F>(&mut self, callback: F) -> Result<(), EspError>
     where
         F: FnMut(EthFrame) + Send + 'static,
     {
-        self.internal_set_rx_callback(callback);
+        self.internal_set_rx_callback(callback)
     }
 
     /// # Safety
@@ -715,14 +715,14 @@ impl<'d, T> EthDriver<'d, T> {
     ///
     /// This "local borrowing" will only be possible to express in a safe way once/if `!Leak` types
     /// are introduced to Rust (i.e. the impossibility to "forget" a type and thus not call its destructor).
-    pub unsafe fn set_nonstatic_rx_callback<F>(&mut self, callback: F)
+    pub unsafe fn set_nonstatic_rx_callback<F>(&mut self, callback: F) -> Result<(), EspError>
     where
         F: FnMut(EthFrame) + Send + 'd,
     {
-        self.internal_set_rx_callback(callback);
+        self.internal_set_rx_callback(callback)
     }
 
-    fn internal_set_rx_callback<F>(&mut self, callback: F)
+    fn internal_set_rx_callback<F>(&mut self, callback: F) -> Result<(), EspError>
     where
         F: FnMut(EthFrame) + Send + 'd,
     {
@@ -737,6 +737,8 @@ impl<'d, T> EthDriver<'d, T> {
         }
 
         self.callback = Some(callback);
+
+        Ok(())
     }
 
     pub fn send(&mut self, frame: &[u8]) -> Result<(), EspError> {

--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -571,7 +571,7 @@ where
         let sender = QuitOnDrop::new(channel);
 
         let subscription = self.subscribe::<EspEvent, _>(move |event| {
-            let mut event = unsafe { core::mem::transmute(event) };
+            let mut event = unsafe { core::mem::transmute::<EspEvent<'_>, EspEvent<'_>>(event) };
 
             sender.channel().share(&mut event);
         })?;

--- a/src/private/mutex.rs
+++ b/src/private/mutex.rs
@@ -50,7 +50,7 @@ impl RawCondvar {
     pub fn new() -> Self {
         let mut cond: pthread_cond_t = Default::default();
 
-        let r = unsafe { pthread_cond_init(&mut cond as *mut _, ptr::null()) };
+        let r = unsafe { pthread_cond_init(ptr::addr_of_mut!(cond), ptr::null()) };
         debug_assert_eq!(r, 0);
 
         Self(UnsafeCell::new(cond))
@@ -72,7 +72,7 @@ impl RawCondvar {
             tv_nsec: (now.tv_usec * 1000) + duration.subsec_nanos() as i32,
         };
 
-        let r = pthread_cond_timedwait(self.0.get(), mutex.0.get(), &abstime as *const _);
+        let r = pthread_cond_timedwait(self.0.get(), mutex.0.get(), ptr::addr_of!(abstime));
         debug_assert!(r == ERR_ETIMEDOUT || r == 0);
 
         r == ERR_ETIMEDOUT

--- a/src/private/net.rs
+++ b/src/private/net.rs
@@ -9,12 +9,12 @@ impl From<ipv4::Ipv4Addr> for Newtype<esp_ip4_addr_t> {
     fn from(ip: ipv4::Ipv4Addr) -> Self {
         let octets = ip.octets();
 
-        let addr = ((octets[0] as u32 & 0xff) << 24)
-            | ((octets[1] as u32 & 0xff) << 16)
-            | ((octets[2] as u32 & 0xff) << 8)
-            | (octets[3] as u32 & 0xff);
+        let addr = ((u32::from(octets[0]) & 0xff) << 24)
+            | ((u32::from(octets[1]) & 0xff) << 16)
+            | ((u32::from(octets[2]) & 0xff) << 8)
+            | (u32::from(octets[3]) & 0xff);
 
-        Newtype(esp_ip4_addr_t {
+        Self(esp_ip4_addr_t {
             addr: u32::from_be(addr),
         })
     }
@@ -31,7 +31,7 @@ impl From<Newtype<esp_ip4_addr_t>> for ipv4::Ipv4Addr {
             (addr & 0xff) as u8,
         );
 
-        ipv4::Ipv4Addr::new(a, b, c, d)
+        Self::new(a, b, c, d)
     }
 }
 
@@ -39,7 +39,7 @@ impl From<ipv4::Ipv4Addr> for Newtype<ip4_addr_t> {
     fn from(ip: ipv4::Ipv4Addr) -> Self {
         let result: Newtype<esp_ip4_addr_t> = ip.into();
 
-        Newtype(ip4_addr_t {
+        Self(ip4_addr_t {
             addr: result.0.addr,
         })
     }
@@ -66,7 +66,7 @@ impl TryFrom<Newtype<esp_ip4_addr_t>> for Mask {
         let ip: ipv4::Ipv4Addr = esp_ip.into();
 
         ip.try_into()
-            .map_err(|_| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
+            .map_err(|()| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
     }
 }
 
@@ -85,13 +85,13 @@ impl TryFrom<Newtype<ip4_addr_t>> for Mask {
         let ip: ipv4::Ipv4Addr = esp_ip.into();
 
         ip.try_into()
-            .map_err(|_| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
+            .map_err(|()| EspError::from_infallible::<ESP_ERR_INVALID_ARG>())
     }
 }
 
 impl From<ipv4::IpInfo> for Newtype<esp_netif_ip_info_t> {
     fn from(ip_info: ipv4::IpInfo) -> Self {
-        Newtype(esp_netif_ip_info_t {
+        Self(esp_netif_ip_info_t {
             ip: Newtype::<esp_ip4_addr_t>::from(ip_info.ip).0,
             netmask: Newtype::<esp_ip4_addr_t>::from(ip_info.subnet.mask).0,
             gw: Newtype::<esp_ip4_addr_t>::from(ip_info.subnet.gateway).0,
@@ -101,7 +101,7 @@ impl From<ipv4::IpInfo> for Newtype<esp_netif_ip_info_t> {
 
 impl From<Newtype<esp_netif_ip_info_t>> for ipv4::IpInfo {
     fn from(ip_info: Newtype<esp_netif_ip_info_t>) -> Self {
-        ipv4::IpInfo {
+        Self {
             ip: ipv4::Ipv4Addr::from(Newtype(ip_info.0.ip)),
             subnet: ipv4::Subnet {
                 gateway: ipv4::Ipv4Addr::from(Newtype(ip_info.0.gw)),

--- a/src/private/stubs.rs
+++ b/src/private/stubs.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_const_for_fn)]
+
 use core::ffi;
 
 // TODO: Figure out which library references this

--- a/src/private/unblocker.rs
+++ b/src/private/unblocker.rs
@@ -48,7 +48,7 @@ where
                 Self::work,
                 task_name,
                 stack_size,
-                worker as *mut _,
+                worker.cast(),
                 priority.unwrap_or(6),
                 pin_to_core,
             )
@@ -73,8 +73,7 @@ where
     }
 
     extern "C" fn work(arg: *mut core::ffi::c_void) {
-        let worker: Box<Box<dyn FnOnce() + Send + 'static>> =
-            unsafe { Box::from_raw(arg as *mut _) };
+        let worker: Box<Box<dyn FnOnce() + Send + 'static>> = unsafe { Box::from_raw(arg.cast()) };
 
         worker();
     }

--- a/src/private/waitable.rs
+++ b/src/private/waitable.rs
@@ -48,7 +48,7 @@ where
         condition: F,
     ) -> Result<bool, EspError> {
         self.wait_timeout_while_and_get(dur, condition, |_| ())
-            .map(|(timeout, _)| timeout)
+            .map(|(timeout, ())| timeout)
     }
 
     pub fn wait_while_and_get<F: FnMut(&T) -> Result<bool, EspError>, G: FnMut(&T) -> Q, Q>(

--- a/src/private/zerocopy.rs
+++ b/src/private/zerocopy.rs
@@ -22,7 +22,7 @@ where
     T: Send + 'static,
 {
     pub fn get_shared(&mut self) -> Option<&mut T> {
-        if let Some(channel) = Weak::upgrade(&self.0) {
+        Weak::upgrade(&self.0).and_then(|channel| {
             let mut guard = channel.state.lock();
 
             loop {
@@ -32,9 +32,7 @@ where
                     State::Data(data) => break unsafe { data.as_mut() },
                 }
             }
-        } else {
-            None
-        }
+        })
     }
 
     pub async fn get_shared_async(&mut self) -> Option<&mut T> {

--- a/src/sntp.rs
+++ b/src/sntp.rs
@@ -22,8 +22,8 @@ mod esp_sntp {
         #[allow(non_upper_case_globals)]
         fn from(from: esp_sntp_operatingmode_t) -> Self {
             match from {
-                esp_sntp_operatingmode_t_ESP_SNTP_OPMODE_POLL => OperatingMode::Poll,
-                esp_sntp_operatingmode_t_ESP_SNTP_OPMODE_LISTENONLY => OperatingMode::ListenOnly,
+                esp_sntp_operatingmode_t_ESP_SNTP_OPMODE_POLL => Self::Poll,
+                esp_sntp_operatingmode_t_ESP_SNTP_OPMODE_LISTENONLY => Self::ListenOnly,
                 _ => unreachable!(),
             }
         }
@@ -99,8 +99,8 @@ impl From<sntp_sync_mode_t> for SyncMode {
     #[allow(non_upper_case_globals)]
     fn from(from: sntp_sync_mode_t) -> Self {
         match from {
-            sntp_sync_mode_t_SNTP_SYNC_MODE_SMOOTH => SyncMode::Smooth,
-            sntp_sync_mode_t_SNTP_SYNC_MODE_IMMED => SyncMode::Immediate,
+            sntp_sync_mode_t_SNTP_SYNC_MODE_SMOOTH => Self::Smooth,
+            sntp_sync_mode_t_SNTP_SYNC_MODE_IMMED => Self::Immediate,
             _ => unreachable!(),
         }
     }
@@ -127,9 +127,9 @@ impl From<sntp_sync_status_t> for SyncStatus {
     #[allow(non_upper_case_globals)]
     fn from(from: sntp_sync_status_t) -> Self {
         match from {
-            sntp_sync_status_t_SNTP_SYNC_STATUS_RESET => SyncStatus::Reset,
-            sntp_sync_status_t_SNTP_SYNC_STATUS_COMPLETED => SyncStatus::Completed,
-            sntp_sync_status_t_SNTP_SYNC_STATUS_IN_PROGRESS => SyncStatus::InProgress,
+            sntp_sync_status_t_SNTP_SYNC_STATUS_RESET => Self::Reset,
+            sntp_sync_status_t_SNTP_SYNC_STATUS_COMPLETED => Self::Completed,
+            sntp_sync_status_t_SNTP_SYNC_STATUS_IN_PROGRESS => Self::InProgress,
             _ => unreachable!(),
         }
     }
@@ -170,7 +170,7 @@ pub struct EspSntp<'a> {
 
 impl EspSntp<'static> {
     pub fn new_default() -> Result<Self, EspError> {
-        Self::new(&Default::default())
+        Self::new(&SntpConf::default())
     }
 
     pub fn new(conf: &SntpConf) -> Result<Self, EspError> {

--- a/src/systime.rs
+++ b/src/systime.rs
@@ -12,12 +12,12 @@ pub struct EspSystemTime;
 impl EspSystemTime {
     /// Return the current system time
     pub fn now(&self) -> Duration {
-        let mut tv_now: timeval = Default::default();
+        let mut tv_now = timeval::default();
 
         unsafe {
-            gettimeofday(&mut tv_now as *mut _, core::ptr::null_mut());
+            gettimeofday(core::ptr::addr_of_mut!(tv_now), core::ptr::null_mut());
         }
 
-        Duration::from_micros(tv_now.tv_sec as u64 * 1000000_u64 + tv_now.tv_usec as u64)
+        Duration::from_micros(tv_now.tv_sec as u64 * 1_000_000_u64 + tv_now.tv_usec as u64)
     }
 }

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -2119,7 +2119,12 @@ impl<'a> EspEventDeserializer for WifiEvent<'a> {
                     .map(|payload| &payload.ap_cred[..payload.ap_cred_cnt as _])
                     .unwrap_or(&[]);
 
-                WifiEvent::StaWpsSuccess(unsafe { core::mem::transmute(credentials) })
+                WifiEvent::StaWpsSuccess(unsafe {
+                    core::mem::transmute::<
+                        &[wifi_event_sta_wps_er_success_t__bindgen_ty_1],
+                        &[WpsCredentialsRef],
+                    >(credentials)
+                })
             }
             wifi_event_t_WIFI_EVENT_STA_WPS_ER_FAILED => WifiEvent::StaWpsFailed,
             wifi_event_t_WIFI_EVENT_STA_WPS_ER_TIMEOUT => WifiEvent::StaWpsTimeout,
@@ -2141,7 +2146,11 @@ impl<'a> EspEventDeserializer for WifiEvent<'a> {
                     (ptr::addr_of!(*data.payload.unwrap()).cast::<wifi_event_ap_staconnected_t>())
                         .as_ref()
                 };
-                WifiEvent::ApStaConnected(unsafe { core::mem::transmute(payload.unwrap()) })
+                WifiEvent::ApStaConnected(unsafe {
+                    core::mem::transmute::<&wifi_event_ap_staconnected_t, &ApStaConnectedRef>(
+                        payload.unwrap(),
+                    )
+                })
             }
             wifi_event_t_WIFI_EVENT_AP_STADISCONNECTED => {
                 let payload = unsafe {
@@ -2149,7 +2158,11 @@ impl<'a> EspEventDeserializer for WifiEvent<'a> {
                         .cast::<wifi_event_ap_stadisconnected_t>())
                     .as_ref()
                 };
-                WifiEvent::ApStaDisconnected(unsafe { core::mem::transmute(payload.unwrap()) })
+                WifiEvent::ApStaDisconnected(unsafe {
+                    core::mem::transmute::<&wifi_event_ap_stadisconnected_t, &ApStaDisconnectedRef>(
+                        payload.unwrap(),
+                    )
+                })
             }
             wifi_event_t_WIFI_EVENT_AP_PROBEREQRECVED => WifiEvent::ApProbeRequestReceived,
             wifi_event_t_WIFI_EVENT_FTM_REPORT => WifiEvent::FtmReport,


### PR DESCRIPTION
Many many lints. Notably:
- Remove unneeded `Result` wrapping some function return types.
- `if ... { panic! }` to `assert!`
- Replaced `if let` with `map_or` and similar.
- [Make `fn` `const` if possible.](https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn)
- [`ptr::addr_of!` instead of `&T as *const T` ](https://rust-lang.github.io/rust-clippy/master/index.html#borrow_as_ptr)
- [`.cast() instead of `*const T as *const U`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_as_ptr)
- [`.cast_mut()` instead of `*const T as *mut T`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_cast_constness)
- [`U::from(T)` instead of `T as U`](https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless)
- `"{}". foo` -> `"{foo}"`
- [Use `Self`](https://rust-lang.github.io/rust-clippy/master/index.html#use_self)
- ...

As many of these are subjective, feel free to modify/request modifications.