### PR TITLE
clippy: Add type annotations to `transmute` calls

### DIFF
--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -573,7 +573,7 @@ where
         let sender = QuitOnDrop::new(channel);
 
         let subscription = self.subscribe::<EspEvent, _>(move |event| {
-            let mut event = unsafe { core::mem::transmute(event) };
+            let mut event = unsafe { mem::transmute::<EspEvent<'_>, EspEvent<'_>>(event) };
 
             sender.channel().share(&mut event);
         })?;

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -2116,7 +2116,12 @@ impl<'a> EspEventDeserializer for WifiEvent<'a> {
                     .map(|payload| &payload.ap_cred[..payload.ap_cred_cnt as _])
                     .unwrap_or(&[]);
 
-                WifiEvent::StaWpsSuccess(unsafe { core::mem::transmute(credentials) })
+                WifiEvent::StaWpsSuccess(unsafe {
+                    core::mem::transmute::<
+                        &[wifi_event_sta_wps_er_success_t__bindgen_ty_1],
+                        &[WpsCredentialsRef],
+                    >(credentials)
+                })
             }
             wifi_event_t_WIFI_EVENT_STA_WPS_ER_FAILED => WifiEvent::StaWpsFailed,
             wifi_event_t_WIFI_EVENT_STA_WPS_ER_TIMEOUT => WifiEvent::StaWpsTimeout,
@@ -2138,14 +2143,22 @@ impl<'a> EspEventDeserializer for WifiEvent<'a> {
                     (data.payload.unwrap() as *const _ as *const wifi_event_ap_staconnected_t)
                         .as_ref()
                 };
-                WifiEvent::ApStaConnected(unsafe { core::mem::transmute(payload.unwrap()) })
+                WifiEvent::ApStaConnected(unsafe {
+                    core::mem::transmute::<&wifi_event_ap_staconnected_t, &ApStaConnectedRef>(
+                        payload.unwrap(),
+                    )
+                })
             }
             wifi_event_t_WIFI_EVENT_AP_STADISCONNECTED => {
                 let payload = unsafe {
                     (data.payload.unwrap() as *const _ as *const wifi_event_ap_stadisconnected_t)
                         .as_ref()
                 };
-                WifiEvent::ApStaDisconnected(unsafe { core::mem::transmute(payload.unwrap()) })
+                WifiEvent::ApStaDisconnected(unsafe {
+                    core::mem::transmute::<&wifi_event_ap_stadisconnected_t, &ApStaDisconnectedRef>(
+                        payload.unwrap(),
+                    )
+                })
             }
             wifi_event_t_WIFI_EVENT_AP_PROBEREQRECVED => WifiEvent::ApProbeRequestReceived,
             wifi_event_t_WIFI_EVENT_FTM_REPORT => WifiEvent::FtmReport,


### PR DESCRIPTION
As requested. The lint is currently only in nightly clippy.