### PR TITLE
ESP-IDF 5.2

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -470,6 +470,11 @@ where
                         ),
                     )))]
                     custom_spi_driver: eth_spi_custom_driver_config_t::default(),
+                    #[cfg(all(
+                        esp_idf_version_major = "5",
+                        not(any(esp_idf_version_minor = "0", esp_idf_version_major = "1"))
+                    ))]
+                    poll_period_ms: 0,
                 };
 
                 let mac = unsafe { esp_eth_mac_new_dm9051(&dm9051_cfg, &mac_cfg) };
@@ -506,6 +511,11 @@ where
                         ),
                     )))]
                     custom_spi_driver: eth_spi_custom_driver_config_t::default(),
+                    #[cfg(all(
+                        esp_idf_version_major = "5",
+                        not(any(esp_idf_version_minor = "0", esp_idf_version_major = "1"))
+                    ))]
+                    poll_period_ms: 0,
                 };
 
                 let mac = unsafe { esp_eth_mac_new_w5500(&w5500_cfg, &mac_cfg) };
@@ -542,6 +552,11 @@ where
                         ),
                     )))]
                     custom_spi_driver: eth_spi_custom_driver_config_t::default(),
+                    #[cfg(all(
+                        esp_idf_version_major = "5",
+                        not(any(esp_idf_version_minor = "0", esp_idf_version_major = "1"))
+                    ))]
+                    poll_period_ms: 0,
                 };
 
                 let mac = unsafe { esp_eth_mac_new_ksz8851snl(&ksz8851snl_cfg, &mac_cfg) };


### PR DESCRIPTION
ESP-IDF 5.2 adds a new field to the SPI ethernet configurations:

> Added option to use SPI Ethernet modules in poll mode without interrupt. [#12682](https://github.com/espressif/esp-idf/issues/12682) ([34ec96e](https://github.com/espressif/esp-idf/commit/34ec96ef23f701a9f72bb988b9195e959e97804d))

So far I have simply added the field and it passes `cargo check`, but there might be some further changes required?