### PR TITLE
Allow disabling IPv6

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -99,6 +99,7 @@ impl EspPing {
         conf: &Configuration,
         tracker: &mut Tracker<F>,
     ) -> Result<(), EspError> {
+        #[cfg(not(esp_idf_lwip_ipv6))]
         let ta = ip4_addr_t {
             addr: u32::from_be_bytes(ip.octets()),
         };


### PR DESCRIPTION
This change allows disabling IPv6 - the type is defined as a union only when IPv4 and IPv6 are enabled [here](https://github.com/espressif/esp-lwip/blob/a45be9e438f6cf9c54ec150581819c3b95d5af6b/src/include/lwip/ip_addr.h#L69)

I'm not sure if it should be patched in this repo, or at bindgen time, let me know