### PR TITLE
Make EspTls and EspAsyncTls Send when possible

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -889,7 +889,7 @@ mod esptls {
         // pub async fn negotiate_server(&mut self, cfg: &ServerConfig<'_>) -> Result<(), EspError> {
         //     // FIXME: this isn't actually async, but esp-idf does not expose anything else.
         //     // we would have to use various hacks to call mbedtls_ssl_handshake by ourself
-        //     self.0.negotiate_server(cfg)
+        //     self.0.borrow_mut().negotiate_server(cfg)
         // }
 
         /// Read in the supplied buffer. Returns the number of bytes read.

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -417,6 +417,16 @@ mod esptls {
         server_session: bool,
     }
 
+    // A single Mbed TLS context itself is safe to send across threads.
+    // Require the threading implementation to be enabled since a shared context such as RSA or X509 could be used by multiple threads at once.
+    // See https://mbed-tls.readthedocs.io/en/latest/kb/development/thread-safety-and-multi-threading/
+    #[cfg(all(
+        esp_idf_comp_esp_tls_enabled,
+        esp_idf_esp_tls_using_mbedtls,
+        esp_idf_mbedtls_threading_c
+    ))]
+    unsafe impl<S> Send for EspTls<S> where S: Send + Socket {}
+
     impl EspTls<InternalSocket> {
         /// Create a new `EspTls` instance using internally-managed socket.
         ///


### PR DESCRIPTION
This is required, for example, by the Hyper HTTP2 client implementation.