### PR TITLE
Fix: Properly complete HTTP response on error

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -506,7 +506,12 @@ impl<'a> EspHttpServer<'a> {
                         connection.handle_error(e);
                     }
                 }
-                Err(e) => connection.handle_error(e),
+                Err(e) => {
+                    connection.handle_error(e);
+                    if let Err(e) = connection.complete() {
+                        connection.handle_error(e);
+                    }
+                }
             }
 
             ESP_OK as _


### PR DESCRIPTION
This commit addresses an issue where the EspHttpServer does not handle errors correctly, causing the HTTP connection to hang indefinitely. When an error is returned from a closure handling an HTTP request, the server logs the error but does not complete the response. As a result, the client hangs indefinitely, waiting for the response to be fully sent. This PR adds a call to `connection.complete()` in the error handling code to ensure that the response is properly finalized.

Fixes: https://github.com/esp-rs/esp-idf-svc/issues/328