### PR TITLE
Mark all non-static handlers as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * eth: callbacks now use newly added EthFrames instead of &[u8]. (#406)
 * wifi: callbacks now use newly added WifiFrames instead of &[u8]. (#406)
 * http_server: Configuration now allows for setting the ctrl_port. (#427)
+* http_server: UB fix: `handler`, `fn_handler` and `handler_chain` all now only accept `'static` callbacks,
+  which is the only safe option in the presence of `core::mem::forget` on the HTTP server. All of those have the
+  previous behavior preserved in the form of `unsafe` `*_nonstatic` variants which were added. (#437)
 * tls: negotiate now returns the new CompletedHandshake struct instead of (). (#428)
 * wifi: Remove AUTOUP as the default flag on ClientConfiguration:Fixed. (#426)
 * tls: Allow TLS negotiation on a multi-threaded executor. (#432)

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -686,6 +686,13 @@ pub trait EspHttpTraversableChain<'a> {
     fn accept(self, server: &mut EspHttpServer<'a>) -> Result<(), EspError>;
 }
 
+/// # Safety
+///
+/// Implementing this trait means that the chain can contain non-`'static` handlers
+/// and that the chain can be used with method `EspHttpServer::handler_chain_nonstatic`.
+///
+/// Consult the documentation of `EspHttpServer::handler_chain_nonstatic` for more
+/// information on how to use non-static handler chains.
 pub unsafe trait EspHttpTraversableChainNonstatic<'a>: EspHttpTraversableChain<'a> {}
 
 impl<'a> EspHttpTraversableChain<'a> for ChainRoot {


### PR DESCRIPTION
This PR "operates" the HTTP server wrapper in a similar way how all other APIs accepting callbacks were altered during the previous release cycle: 
- All APIs which used to take non-static callbacks, now only accept `'static` ones, which is safe
- All of them now also have a mirror `_nonstatic` APIs marked with `unsafe` which continue to accept non-`'static` callbacks, but have big fat `#Safety` strings attached

With this PR, what would happen to the code that was posted in Matrix by a user, is that the code would stop compiling, because the handlers are non-static in that they borrow a ref to a `Mutex` which lives on the stack (and the program crashes because additionally it calls `core::mem::forget` on a value that continues to live after the stack had gone).
