### PR TITLE
Use ws url based on current page's url

### DIFF
--- a/examples/http_ws_server_page.html
+++ b/examples/http_ws_server_page.html
@@ -35,7 +35,7 @@ const serverResp = document.getElementById("server-resp");
 let ws;
 
 function loadWebSocket() {
-    ws = new WebSocket("ws://192.168.71.1/ws/guess");
+    ws = new WebSocket(`ws://${window.location.host}/ws/guess`);
     ws.onopen = function(e) {
         submitButton.disabled = false;
     };


### PR DESCRIPTION
Instead of using a fixed URL, base the ws url based off of the current http URL. This will make it easier to modify the examples, such as connecting to an existing Wi-Fi network instead of creating one.