### PR TITLE
Support for esp32c2, esp32h2, esp32c6 and in future esp32h4 and esp32c5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,12 @@ jobs:
       matrix:
         target:
           - riscv32imc-esp-espidf
+          - riscv32imac-esp-espidf
           - xtensa-esp32-espidf
           - xtensa-esp32s2-espidf
           - xtensa-esp32s3-espidf
         idf-version:
-          - v4.4.6
+          - v4.4.7
           - v5.1.2
           - v5.2
     steps:
@@ -84,6 +85,7 @@ jobs:
           chmod a+x $HOME/.cargo/bin/ldproxy
 
       - name: Build | Examples
+        if: matrix.target != 'riscv32imac-esp-espidf'
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           ESP_IDF_SDKCONFIG_DEFAULTS: "${{ github.workspace }}/.github/configs/sdkconfig.defaults"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.1] - 2024-07-??
+### Fixed
+* Bluetooth: The experimental Bluedroid support did not compile on esp32c2, esp32h2 and esp32c6 (#447)
+
 ## [0.49.0] - 2024-06-23
 
 ### Deprecated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ build = "build.rs"
 documentation = "https://docs.esp-rs.org/esp-idf-svc/"
 rust-version = "1.77"
 
+[patch.crates-io]
+esp-idf-hal = { git = "https://github.com/esp-rs/esp-idf-hal" }
+
 [features]
 default = ["std", "binstart"]
 

--- a/src/bt.rs
+++ b/src/bt.rs
@@ -466,33 +466,33 @@ where
     fn init(_nvs_enabled: bool) -> Result<(), EspError> {
         #[cfg(esp32)]
         let mut bt_cfg = esp_bt_controller_config_t {
-            magic: ESP_BT_CONTROLLER_CONFIG_MAGIC_VAL,
-            controller_task_stack_size: ESP_TASK_BT_CONTROLLER_STACK as _,
-            controller_task_prio: ESP_TASK_BT_CONTROLLER_PRIO as _,
-            hci_uart_no: BT_HCI_UART_NO_DEFAULT as _,
-            hci_uart_baudrate: BT_HCI_UART_BAUDRATE_DEFAULT,
-            scan_duplicate_mode: SCAN_DUPLICATE_MODE as _,
-            scan_duplicate_type: SCAN_DUPLICATE_TYPE_VALUE as _,
-            normal_adv_size: NORMAL_SCAN_DUPLICATE_CACHE_SIZE as _,
-            mesh_adv_size: MESH_DUPLICATE_SCAN_CACHE_SIZE as _,
-            send_adv_reserved_size: SCAN_SEND_ADV_RESERVED_SIZE as _,
-            controller_debug_flag: CONTROLLER_ADV_LOST_DEBUG_BIT,
+            magic: crate::sys::ESP_BT_CONTROLLER_CONFIG_MAGIC_VAL,
+            controller_task_stack_size: crate::sys::ESP_TASK_BT_CONTROLLER_STACK as _,
+            controller_task_prio: crate::sys::ESP_TASK_BT_CONTROLLER_PRIO as _,
+            hci_uart_no: crate::sys::BT_HCI_UART_NO_DEFAULT as _,
+            hci_uart_baudrate: crate::sys::BT_HCI_UART_BAUDRATE_DEFAULT,
+            scan_duplicate_mode: crate::sys::SCAN_DUPLICATE_MODE as _,
+            scan_duplicate_type: crate::sys::SCAN_DUPLICATE_TYPE_VALUE as _,
+            normal_adv_size: crate::sys::NORMAL_SCAN_DUPLICATE_CACHE_SIZE as _,
+            mesh_adv_size: crate::sys::MESH_DUPLICATE_SCAN_CACHE_SIZE as _,
+            send_adv_reserved_size: crate::sys::SCAN_SEND_ADV_RESERVED_SIZE as _,
+            controller_debug_flag: crate::sys::CONTROLLER_ADV_LOST_DEBUG_BIT,
             mode: M::mode() as _,
-            ble_max_conn: CONFIG_BTDM_CTRL_BLE_MAX_CONN_EFF as _,
-            bt_max_acl_conn: CONFIG_BTDM_CTRL_BR_EDR_MAX_ACL_CONN_EFF as _,
-            bt_sco_datapath: CONFIG_BTDM_CTRL_BR_EDR_SCO_DATA_PATH_EFF as _,
-            auto_latency: BTDM_CTRL_AUTO_LATENCY_EFF != 0,
-            bt_legacy_auth_vs_evt: BTDM_CTRL_LEGACY_AUTH_VENDOR_EVT_EFF != 0,
-            bt_max_sync_conn: CONFIG_BTDM_CTRL_BR_EDR_MAX_SYNC_CONN_EFF as _,
-            ble_sca: CONFIG_BTDM_BLE_SLEEP_CLOCK_ACCURACY_INDEX_EFF as _,
-            pcm_role: CONFIG_BTDM_CTRL_PCM_ROLE_EFF as _,
-            pcm_polar: CONFIG_BTDM_CTRL_PCM_POLAR_EFF as _,
-            hli: BTDM_CTRL_HLI != 0,
-            dup_list_refresh_period: SCAN_DUPL_CACHE_REFRESH_PERIOD as _,
+            ble_max_conn: crate::sys::CONFIG_BTDM_CTRL_BLE_MAX_CONN_EFF as _,
+            bt_max_acl_conn: crate::sys::CONFIG_BTDM_CTRL_BR_EDR_MAX_ACL_CONN_EFF as _,
+            bt_sco_datapath: crate::sys::CONFIG_BTDM_CTRL_BR_EDR_SCO_DATA_PATH_EFF as _,
+            auto_latency: crate::sys::BTDM_CTRL_AUTO_LATENCY_EFF != 0,
+            bt_legacy_auth_vs_evt: crate::sys::BTDM_CTRL_LEGACY_AUTH_VENDOR_EVT_EFF != 0,
+            bt_max_sync_conn: crate::sys::CONFIG_BTDM_CTRL_BR_EDR_MAX_SYNC_CONN_EFF as _,
+            ble_sca: crate::sys::CONFIG_BTDM_BLE_SLEEP_CLOCK_ACCURACY_INDEX_EFF as _,
+            pcm_role: crate::sys::CONFIG_BTDM_CTRL_PCM_ROLE_EFF as _,
+            pcm_polar: crate::sys::CONFIG_BTDM_CTRL_PCM_POLAR_EFF as _,
+            hli: crate::sys::BTDM_CTRL_HLI != 0,
+            dup_list_refresh_period: crate::sys::SCAN_DUPL_CACHE_REFRESH_PERIOD as _,
             ..Default::default()
         };
 
-        #[cfg(not(any(esp32, esp32s3)))]
+        #[cfg(esp32c3)]
         let mut bt_cfg = esp_bt_controller_config_t {
             magic: crate::sys::ESP_BT_CTRL_CONFIG_MAGIC_VAL,
             version: crate::sys::ESP_BT_CTRL_CONFIG_VERSION,
@@ -568,6 +568,74 @@ where
                                  // ble_50_feat_supp: crate::sys::BT_CTRL_50_FEATURE_SUPPORT != 0,
                                  // dup_list_refresh_period: crate::sys::DUPL_SCAN_CACHE_REFRESH_PERIOD as _,
                                  // scan_backoff_upperlimitmax: crate::sys::BT_CTRL_SCAN_BACKOFF_UPPERLIMITMAX as _
+        };
+
+        #[cfg(not(any(esp32, esp32s3, esp32c3)))]
+        let mut bt_cfg = esp_bt_controller_config_t {
+            config_version: 0x20231124,
+            ble_ll_resolv_list_size: crate::sys::CONFIG_BT_LE_LL_RESOLV_LIST_SIZE as _,
+            ble_hci_evt_hi_buf_count: crate::sys::DEFAULT_BT_LE_HCI_EVT_HI_BUF_COUNT as _,
+            ble_hci_evt_lo_buf_count: crate::sys::DEFAULT_BT_LE_HCI_EVT_LO_BUF_COUNT as _,
+            ble_ll_sync_list_cnt: crate::sys::DEFAULT_BT_LE_MAX_PERIODIC_ADVERTISER_LIST as _,
+            ble_ll_sync_cnt: crate::sys::DEFAULT_BT_LE_MAX_PERIODIC_SYNCS as _,
+            ble_ll_rsp_dup_list_count: crate::sys::CONFIG_BT_LE_LL_DUP_SCAN_LIST_COUNT as _,
+            ble_ll_adv_dup_list_count: crate::sys::CONFIG_BT_LE_LL_DUP_SCAN_LIST_COUNT as _,
+            ble_ll_tx_pwr_dbm: crate::sys::BLE_LL_TX_PWR_DBM_N as _,
+            rtc_freq: crate::sys::RTC_FREQ_N as _,
+            ble_ll_sca: crate::sys::CONFIG_BT_LE_LL_SCA as _,
+            ble_ll_scan_phy_number: crate::sys::BLE_LL_SCAN_PHY_NUMBER_N as _,
+            ble_ll_conn_def_auth_pyld_tmo: crate::sys::BLE_LL_CONN_DEF_AUTH_PYLD_TMO_N as _,
+            ble_ll_jitter_usecs: crate::sys::BLE_LL_JITTER_USECS_N as _,
+            ble_ll_sched_max_adv_pdu_usecs: crate::sys::BLE_LL_SCHED_MAX_ADV_PDU_USECS_N as _,
+            ble_ll_sched_direct_adv_max_usecs: crate::sys::BLE_LL_SCHED_DIRECT_ADV_MAX_USECS_N as _,
+            ble_ll_sched_adv_max_usecs: crate::sys::BLE_LL_SCHED_ADV_MAX_USECS_N as _,
+            ble_scan_rsp_data_max_len: crate::sys::DEFAULT_BT_LE_SCAN_RSP_DATA_MAX_LEN_N as _,
+            ble_ll_cfg_num_hci_cmd_pkts: crate::sys::BLE_LL_CFG_NUM_HCI_CMD_PKTS_N as _,
+            ble_ll_ctrl_proc_timeout_ms: crate::sys::BLE_LL_CTRL_PROC_TIMEOUT_MS_N,
+            nimble_max_connections: crate::sys::DEFAULT_BT_LE_MAX_CONNECTIONS as _,
+            ble_whitelist_size: crate::sys::DEFAULT_BT_NIMBLE_WHITELIST_SIZE as _,
+            ble_acl_buf_size: crate::sys::DEFAULT_BT_LE_ACL_BUF_SIZE as _,
+            ble_acl_buf_count: crate::sys::DEFAULT_BT_LE_ACL_BUF_COUNT as _,
+            ble_hci_evt_buf_size: crate::sys::DEFAULT_BT_LE_HCI_EVT_BUF_SIZE as _,
+            ble_multi_adv_instances: crate::sys::DEFAULT_BT_LE_MAX_EXT_ADV_INSTANCES as _,
+            ble_ext_adv_max_size: crate::sys::DEFAULT_BT_LE_EXT_ADV_MAX_SIZE as _,
+            controller_task_stack_size: crate::sys::NIMBLE_LL_STACK_SIZE as _,
+            controller_task_prio: crate::sys::ESP_TASK_BT_CONTROLLER_PRIO as _,
+            controller_run_cpu: 0,
+            enable_qa_test: crate::sys::RUN_QA_TEST as _,
+            enable_bqb_test: crate::sys::RUN_BQB_TEST as _,
+            enable_uart_hci: crate::sys::HCI_UART_EN as _,
+            ble_hci_uart_port: crate::sys::DEFAULT_BT_LE_HCI_UART_PORT as _,
+            ble_hci_uart_baud: crate::sys::DEFAULT_BT_LE_HCI_UART_BAUD,
+            ble_hci_uart_data_bits: crate::sys::DEFAULT_BT_LE_HCI_UART_DATA_BITS as _,
+            ble_hci_uart_stop_bits: crate::sys::DEFAULT_BT_LE_HCI_UART_STOP_BITS as _,
+            ble_hci_uart_flow_ctrl: crate::sys::DEFAULT_BT_LE_HCI_UART_FLOW_CTRL as _,
+            ble_hci_uart_uart_parity: crate::sys::DEFAULT_BT_LE_HCI_UART_PARITY as _,
+            enable_tx_cca: crate::sys::DEFAULT_BT_LE_TX_CCA_ENABLED as _,
+            cca_rssi_thresh: (256 - crate::sys::DEFAULT_BT_LE_CCA_RSSI_THRESH) as _,
+            sleep_en: crate::sys::NIMBLE_SLEEP_ENABLE as _,
+            coex_phy_coded_tx_rx_time_limit: crate::sys::DEFAULT_BT_LE_COEX_PHY_CODED_TX_RX_TLIM_EFF
+                as _,
+            dis_scan_backoff: crate::sys::NIMBLE_DISABLE_SCAN_BACKOFF as _,
+            ble_scan_classify_filter_enable: 1,
+            main_xtal_freq: crate::sys::CONFIG_XTAL_FREQ as _,
+            #[cfg(esp32c2)]
+            version_num: unsafe { crate::sys::esp_ble_get_chip_rev_version() },
+            #[cfg(esp32c6)]
+            version_num: unsafe { crate::sys::efuse_hal_chip_revision() },
+            #[cfg(not(esp32c2))]
+            cpu_freq_mhz: crate::sys::CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ as _,
+            ignore_wl_for_direct_adv: 0,
+            #[cfg(not(esp32c2))]
+            enable_pcl: crate::sys::DEFAULT_BT_LE_POWER_CONTROL_ENABLED as _,
+            #[cfg(all(
+                not(esp_idf_version_major = "4"),
+                not(esp_idf_version = "5.0"),
+                not(esp_idf_version = "5.1")
+            ))]
+            csa2_select: crate::sys::DEFAULT_BT_LE_50_FEATURE_SUPPORT as _,
+            config_magic: 0x5A5AA5A5,
+            ..Default::default()
         };
 
         info!("Init bluetooth controller");


### PR DESCRIPTION
Subject says it all.
BT controller initialization for these chips is different from the currently supported esp32/esp32c3/esp32s3.