### PR TITLE
BUGFIX: The SpiEventSource impl block should be compiled under the same conditions as the st…

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -155,6 +155,11 @@ pub struct SpiEventSource<'d> {
     _p: PhantomData<&'d mut ()>,
 }
 
+#[cfg(any(
+    esp_idf_eth_spi_ethernet_dm9051,
+    esp_idf_eth_spi_ethernet_w5500,
+    esp_idf_eth_spi_ethernet_ksz8851snl
+))]
 impl<'d> SpiEventSource<'d> {
     /// Instead of getting informed by an interrupt pin about updates/changes from the emac, the
     /// MCU polls the emac periodically for updates.


### PR DESCRIPTION
…ruct block.