### PR TITLE
get_scan_result version stomps the scan state from Done to Idle.

### DIFF
--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -950,8 +950,6 @@ impl<'d> WifiDriver<'d> {
 
         let fetched_count = self.fetch_scan_result(&mut ap_infos_raw)?;
 
-        self.status.lock().scan = WifiScanStatus::Idle;
-
         let result = ap_infos_raw[..fetched_count]
             .iter()
             .map::<Result<AccessPointInfo, Utf8Error>, _>(|ap_info_raw| {


### PR DESCRIPTION
I am using the is_scan_done function to check if I can start a new scan. I noticed this problem when I switched from using get_scan_result_n() to get_scan_result(). The state behavior should at least be matched.