### PR TITLE
Make async mqtt client implement Send

### DIFF
--- a/src/private/unblocker.rs
+++ b/src/private/unblocker.rs
@@ -20,6 +20,10 @@ where
     task: TaskHandle_t,
 }
 
+/// SAFETY: Unblocker uses a raw pointer in Unblocker::task. This causes rust to treat it as not Send.
+/// However, this task handle is only ever used to delete the FreeRTOS task, which is safe to do from any thread.
+unsafe impl<T: Send + 'static> Send for Unblocker<T> {}
+
 impl<T> Unblocker<T>
 where
     T: Send + 'static,

--- a/src/private/zerocopy.rs
+++ b/src/private/zerocopy.rs
@@ -83,7 +83,7 @@ where
     }
 }
 
-unsafe impl<T> Send for Receiver<T> where T: Send + 'static {}
+unsafe impl<'a, T> Send for Receiver<T> where T: Send + 'a {}
 
 pub struct QuitOnDrop<T>(Arc<Channel<T>>)
 where
@@ -182,8 +182,8 @@ where
     }
 }
 
-unsafe impl<T> Send for Channel<T> where T: Send + 'static {}
-unsafe impl<T> Sync for Channel<T> where T: Send + 'static {}
+unsafe impl<'a, T> Send for Channel<T> where T: Send + 'a {}
+unsafe impl<'a, T> Sync for Channel<T> where T: Send + 'a {}
 
 #[derive(Copy, Clone, Debug)]
 enum State<T> {


### PR DESCRIPTION
There were already some Send implementations.
However, they weren't completely correct, which made it impossible to use the async mqtt client in e.g. a tokio worker thread.

Note that it could be used in the async main task, because that never sends off any work to other worker threads, and thus Send is not required. The errors would surface when trying to use tokio::spawn with an async mqtt client.

See also https://users.rust-lang.org/t/implementation-of-send-is-not-general-enough-but-cannot-make-it-more-general/115087


Also. I note that the Unblocker deletes the FreeRTOS task when it is dropped. This seems sketchy. Deleting the task will, if I understand correctly, cause it to stop running immediately, without running any associated `Drop` implementations. Couldn't this cause memory leaks? Wouldn't it be better to just let it close the channel and let the worker thread clean itself up?