### PR TITLE
Make EspAsyncMqttClient::wrap public.

### DIFF
--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -756,7 +756,7 @@ impl EspAsyncMqttClient {
         Ok((client, conn))
     }
 
-    fn wrap(client: EspMqttClient<'static>) -> Result<Self, EspError> {
+    pub fn wrap(client: EspMqttClient<'static>) -> Result<Self, EspError> {
         let unblocker = Unblocker::new(
             CStr::from_bytes_until_nul(b"MQTT Sending task\0").unwrap(),
             4096,


### PR DESCRIPTION
This will allow users to use the `EspMqttClient::new_cb` method together with the async mqtt client, if one should so desire. For example, if one wants to use a different event channel.