### PR TITLE
Implement Sync for EspMqttEvent.

### DIFF
--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -985,6 +985,7 @@ impl<'a> EspMqttEvent<'a> {
 }
 
 unsafe impl<'a> Send for EspMqttEvent<'a> {}
+unsafe impl<'a> Sync for EspMqttEvent<'a> {}
 
 impl<'a> ErrorType for EspMqttEvent<'a> {
     type Error = EspError;


### PR DESCRIPTION
Forgot this one in the previous PR.
Without it, I can get errors like this:

```rust
error[E0277]: `*mut esp_mqtt_error_codes` cannot be shared between threads safely
     --> /home/arong/projects/embedded/mqtt_sync/src/lib.rs:156:9
      |
156   | /         tokio::spawn(async move {
157   | |             Self::start(client, connection, queue_receiver, storage2)
158   | |                 .await
159   | |                 .unwrap()
160   | |         });
      | |__________^ `*mut esp_mqtt_error_codes` cannot be shared between threads safely
      |
      = help: within `EspMqttEvent<'_>`, the trait `Sync` is not implemented for `*mut esp_mqtt_error_codes`, which is required by `{async block@/home/arong/projects/embedded/mqtt_sync/src/lib.rs:156:22: 160:10}: Send`
note: required because it appears within the type `esp_mqtt_event_t`
     --> /home/arong/projects/embedded/bedroom_lights/target/xtensa-esp32-espidf/debug/build/esp-idf-sys-c35dc8de562f89fd/out/bindings.rs:46943:12
      |
46943 | pub struct esp_mqtt_event_t {
      |            ^^^^^^^^^^^^^^^^
      = note: required because it appears within the type `&esp_mqtt_event_t`
note: required because it appears within the type `EspMqttEvent<'_>`
     --> /home/arong/projects/embedded/esp-idf-svc/src/mqtt/client.rs:913:12
      |
913   | pub struct EspMqttEvent<'a>(&'a esp_mqtt_event_t);
      |            ^^^^^^^^^^^^
      = note: required for `&EspMqttEvent<'_>` to implement `Send`
note: required because it's used within this `async` block
     --> /home/arong/projects/embedded/mqtt_sync/src/lib.rs:253:27
      |
253   |           let listen = pin!(async move {
      |  ___________________________^
254   | |             while let Ok(event) = connection.next().await {
255   | |                 let t = t0.elapsed();
256   | |                 let payload = event.payload();
...     |
332   | |             Result::<(), C::Error>::Ok(())
333   | |         });
      | |_________^
note: required because it's used within this `async` fn body
     --> /home/arong/projects/embedded/mqtt_sync/src/lib.rs:240:31
      |
240   |       ) -> Result<(), C::Error> {
      |  _______________________________^
241   | |         let t0 = std::time::Instant::now();
242   | |         let (reconnect_sender, mut reconnect_receiver) = tokio::sync::mpsc::channel::<()>(2);
...     |
433   | |         res
434   | |     }
      | |_____^
```
