### PR TITLE
Remove unnecessary buffer draining in HTTP client example

### DIFF
--- a/examples/http_client.rs
+++ b/examples/http_client.rs
@@ -93,9 +93,6 @@ fn get_request(client: &mut HttpClient<EspHttpConnection>) -> anyhow::Result<()>
         Err(e) => error!("Error decoding response body: {}", e),
     };
 
-    // Drain the remaining response bytes
-    while response.read(&mut buf)? > 0 {}
-
     Ok(())
 }
 
@@ -134,9 +131,6 @@ fn post_request(client: &mut HttpClient<EspHttpConnection>) -> anyhow::Result<()
         Err(e) => error!("Error decoding response body: {}", e),
     };
 
-    // Drain the remaining response bytes
-    while response.read(&mut buf)? > 0 {}
-
     Ok(())
 }
 
@@ -172,9 +166,6 @@ fn post_chunked_request(client: &mut HttpClient<EspHttpConnection>) -> anyhow::R
         ),
         Err(e) => error!("Error decoding response body: {}", e),
     };
-
-    // Drain the remaining response bytes
-    while response.read(&mut buf)? > 0 {}
 
     Ok(())
 }


### PR DESCRIPTION
#404 renders this code unnecessary:

```
// Drain the remaining response bytes
while response.read(&mut buf)? > 0 {}
```

Note: I tested on my machine. The [http_client.rs](https://github.com/esp-rs/esp-idf-svc/blob/master/examples/http_client.rs) example still runs successfully.