### PR TITLE
Fix for ESP-IDF 5.3

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -437,13 +437,26 @@ impl<'d> EthDriver<'d, RmiiEth> {
     #[cfg(any(
         esp_idf_version = "5.0",
         esp_idf_version = "5.1",
-        esp_idf_version = "5.2",
-        esp_idf_version = "5.3"
+        esp_idf_version = "5.2"
     ))]
     fn eth_esp32_emac_default_config(mdc: i32, mdio: i32) -> eth_esp32_emac_config_t {
         eth_esp32_emac_config_t {
             smi_mdc_gpio_num: mdc,
             smi_mdio_gpio_num: mdio,
+            interface: eth_data_interface_t_EMAC_DATA_INTERFACE_RMII,
+            ..Default::default()
+        }
+    }
+
+    #[cfg(esp_idf_version = "5.3")]
+    fn eth_esp32_emac_default_config(mdc: i32, mdio: i32) -> eth_esp32_emac_config_t {
+        eth_esp32_emac_config_t {
+            __bindgen_anon_1: eth_esp32_emac_config_t__bindgen_ty_1 {
+                __bindgen_anon_1: eth_esp32_emac_config_t__bindgen_ty_1__bindgen_ty_1 {
+                    smi_mdc_gpio_num: mdc,
+                    smi_mdio_gpio_num: mdio,
+                },
+            },
             interface: eth_data_interface_t_EMAC_DATA_INTERFACE_RMII,
             ..Default::default()
         }


### PR DESCRIPTION
Fix for this error:

```
   Compiling esp-idf-svc v0.49.1 (esp-idf-svc)
error[E0560]: struct `esp_idf_hal::sys::eth_esp32_emac_config_t` has no field named `smi_mdc_gpio_num`
   --> esp-idf-svc/src/eth.rs:445:13
    |
445 |             smi_mdc_gpio_num: mdc,
    |             ^^^^^^^^^^^^^^^^ `esp_idf_hal::sys::eth_esp32_emac_config_t` does not have this field
    |
    = note: available fields are: `__bindgen_anon_1`, `clock_config`, `dma_burst_len`, `intr_priority`

error[E0560]: struct `esp_idf_hal::sys::eth_esp32_emac_config_t` has no field named `smi_mdio_gpio_num`
   --> esp-idf-svc/src/eth.rs:446:13
    |
446 |             smi_mdio_gpio_num: mdio,
    |             ^^^^^^^^^^^^^^^^^ `esp_idf_hal::sys::eth_esp32_emac_config_t` does not have this field
    |
    = note: available fields are: `__bindgen_anon_1`, `clock_config`, `dma_burst_len`, `intr_priority`

For more information about this error, try `rustc --explain E0560`.
error: could not compile `esp-idf-svc` (lib) due to 2 previous errors
```

It seems like a simple case of union / bindgen noise.