### PR TITLE
Added IP_EVENT_ETH_LOST_IP to deserialize list

### DIFF
--- a/src/netif.rs
+++ b/src/netif.rs
@@ -765,6 +765,7 @@ impl<'a> EspEventDeserializer for IpEvent<'a> {
             IpEvent::DhcpIp6Assigned(DhcpIp6Assignment(event))
         } else if event_id == ip_event_t_IP_EVENT_STA_LOST_IP
             || event_id == ip_event_t_IP_EVENT_PPP_LOST_IP
+            || event_id == ip_event_t_IP_EVENT_ETH_LOST_IP
         {
             let netif_handle_mut = unsafe {
                 (data.payload.unwrap() as *const _ as *mut esp_netif_t)


### PR DESCRIPTION
The function deserialize did not check for the event IP_EVENT_ETH_LOST_IP when the ethernet driver lost the IP, instead, it panic'd when the IP is lost. This patch fixes that by additionally checking for the ETH_LOST_IP event and propagates it as a DhcpIpDeassigned event.