### PR TITLE
Document OTA API

### DIFF
--- a/src/ota.rs
+++ b/src/ota.rs
@@ -238,8 +238,9 @@ impl<'a> EspOtaUpdate<'a> {
         Ok(())
     }
 
-    /// No-op: the OTA update is aborted when `EspOtaUpdate` is dropped.
+    /// Cancels the update.
     pub fn abort(self) -> Result<(), EspError> {
+        // The OTA update is aborted when `EspOtaUpdate` is dropped.
         Ok(())
     }
 
@@ -274,6 +275,7 @@ pub struct EspOtaUpdateFinished<'a> {
 
 impl EspOtaUpdateFinished<'_> {
     /// Sets the boot partition to the newly updated app partition.
+    /// The app will be run on the next boot.
     pub fn activate(self) -> Result<(), EspError> {
         esp!(unsafe { esp_ota_set_boot_partition(self.update_partition) })
     }


### PR DESCRIPTION
I've been recently implementing OTA for my project and noticed the documentation was lacking. I decided to add documentation to improve my own understanding and hopefully make it more accessible to others.

I used [ESP-IDF OTA documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/ota.html) for reference.

As I'm not an expert here, I would appreciate if someone could check the correctness, especially the module doc.

Additionally, I'm not sure about the contents of `EspOtaUpdate::flush()`. On one hand, this function does nothing and the user may want to know about it, on the other hand, I just exposed implementation details. Should the documentation be written with the assumption that this function does something? This would encourage users to use it and ensure compatibility with future updates.