### PR TITLE
Fix incorrect logging configuration attribute introduced in #494

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -258,7 +258,7 @@ impl ::log::Log for EspLogger {
                 write!(stdout, "\x1b[0;{}m", color).unwrap();
             }
             write!(stdout, "{} (", marker).unwrap();
-            if cfg!(esp_idf_log_timestamp_rtos) {
+            if cfg!(esp_idf_log_timestamp_source_rtos) {
                 let timestamp = unsafe { esp_log_timestamp() };
                 write!(stdout, "{}", timestamp).unwrap();
             } else if cfg!(esp_idf_log_timestamp_source_system) {


### PR DESCRIPTION
In #494 an issue with an incorrect configuration attribute was introduced and the regular CONFIG_LOG_TIMESTAMP_SOURCE_RTOS option is not usable anymore. This is a fix for this bug