### PR TITLE
examples/http_ws_server.rs: fix string decoding

### DIFF
--- a/examples/http_ws_server.rs
+++ b/examples/http_ws_server.rs
@@ -169,7 +169,13 @@ fn main() -> anyhow::Result<()> {
 
         let mut buf = [0; MAX_LEN]; // Small digit buffer can go on the stack
         ws.recv(buf.as_mut())?;
-        let Ok(user_string) = str::from_utf8(&buf[..len]) else {
+        
+        let Ok(user_string) = CStr::from_bytes_until_nul(&buf[..len]) else {
+            ws.send(FrameType::Text(false), "[CStr decode Error]".as_bytes())?;
+            return Ok(());
+        };
+
+        let Ok(user_string) = user_string.to_str() else {
             ws.send(FrameType::Text(false), "[UTF-8 Error]".as_bytes())?;
             return Ok(());
         };

--- a/examples/http_ws_server.rs
+++ b/examples/http_ws_server.rs
@@ -169,7 +169,7 @@ fn main() -> anyhow::Result<()> {
 
         let mut buf = [0; MAX_LEN]; // Small digit buffer can go on the stack
         ws.recv(buf.as_mut())?;
-        
+
         let Ok(user_string) = CStr::from_bytes_until_nul(&buf[..len]) else {
             ws.send(FrameType::Text(false), "[CStr decode Error]".as_bytes())?;
             return Ok(());

--- a/examples/http_ws_server.rs
+++ b/examples/http_ws_server.rs
@@ -25,7 +25,7 @@ use esp_idf_svc::sys::{EspError, ESP_ERR_INVALID_SIZE};
 
 use log::*;
 
-use std::{borrow::Cow, collections::BTreeMap, str, sync::Mutex};
+use std::{borrow::Cow, collections::BTreeMap, ffi::CStr, str, sync::Mutex};
 
 const SSID: &str = env!("WIFI_SSID");
 const PASSWORD: &str = env!("WIFI_PASS");


### PR DESCRIPTION
a (supposed) C string was treated/decoded as Rust string. This works okay-ish, but leads to a trailing null byte (valid in UTF-8!) which e.g. `serde_json` doesn't like.