### PR TITLE
Fix missing newline if CONFIG_LOG_COLORS=n is set

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -272,8 +272,9 @@ impl ::log::Log for EspLogger {
             }
             write!(stdout, ") {}: {}", target, args).unwrap();
             if color.is_some() {
-                writeln!(stdout, "\x1b[0m").unwrap();
+                write!(stdout, "\x1b[0m").unwrap();
             }
+            writeln!(stdout).unwrap();
         }
     }
 


### PR DESCRIPTION
Fixes #520 where no newlines were printed if `CONFIG_LOG_COLORS=n` as the newline was only printed if `color.is_some()`.
Now the `writeln!()` call is at the end and is always called.