### PR TITLE
gatekeep mdns ipv6 behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,7 @@ esp-idf-hal = { git = "https://github.com/esp-rs/esp-idf-hal" }
 esp-idf-sys = { git = "https://github.com/esp-rs/esp-idf-sys" }
 
 [features]
-default = ["std", "binstart", "mdns_ipv6"]
-
-mdns_ipv6 = []
+default = ["std", "binstart"]
 
 std = ["alloc", "log/std", "esp-idf-hal/std", "embedded-svc/std", "futures-io"]
 alloc = ["esp-idf-hal/alloc", "embedded-svc/alloc", "uncased/alloc"]
@@ -44,7 +42,6 @@ alloc_handler = ["esp-idf-hal/alloc_handler"]
 panic_handler = ["esp-idf-hal/panic_handler"]
 binstart = ["esp-idf-hal/binstart"]
 libstart = ["esp-idf-hal/libstart"]
-
 
 [dependencies]
 heapless = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ esp-idf-sys = { git = "https://github.com/esp-rs/esp-idf-sys" }
 cmake = { git = "https://github.com/ivmarkov/cmake-rs" }
 
 [features]
-default = ["std", "binstart"]
+default = ["std", "binstart", "mdns_ipv6"]
+
+mdns_ipv6 = []
 
 std = ["alloc", "log/std", "esp-idf-hal/std", "embedded-svc/std", "futures-io"]
 alloc = ["esp-idf-hal/alloc", "embedded-svc/alloc", "uncased/alloc"]
@@ -43,6 +45,7 @@ alloc_handler = ["esp-idf-hal/alloc_handler"]
 panic_handler = ["esp-idf-hal/panic_handler"]
 binstart = ["esp-idf-hal/binstart"]
 libstart = ["esp-idf-hal/libstart"]
+
 
 [dependencies]
 heapless = { version = "0.8", default-features = false }

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 
 use ::log::info;
 
-#[cfg(feature = "esp_idf_lwip_ipv6")]
+#[cfg(esp_idf_lwip_ipv6)]
 use embedded_svc::ipv4::Ipv6Addr;
 use embedded_svc::ipv4::{IpAddr, Ipv4Addr};
 
@@ -29,14 +29,14 @@ pub enum Interface {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Protocol {
     V4,
-    #[cfg(feature = "esp_idf_lwip_ipv6")]
+    #[cfg(esp_idf_lwip_ipv6)]
     V6,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Type {
     A = MDNS_TYPE_A as _,
-    #[cfg(feature = "esp_idf_lwip_ipv6")]
+    #[cfg(esp_idf_lwip_ipv6)]
     AAAA = MDNS_TYPE_AAAA as _,
     ANY = MDNS_TYPE_ANY as _,
     NSEC = MDNS_TYPE_NSEC as _,
@@ -87,7 +87,7 @@ impl From<mdns_result_t> for QueryResult {
             let a = unsafe { (*p).addr };
             let a = match a.type_ as _ {
                 ESP_IPADDR_TYPE_V4 => IpAddr::V4(from_esp_ip4_addr_t(unsafe { &a.u_addr.ip4 })),
-                #[cfg(feature = "esp_idf_lwip_ipv6")]
+                #[cfg(esp_idf_lwip_ipv6)]
                 ESP_IPADDR_TYPE_V6 => IpAddr::V6(from_esp_ip6_addr_t(unsafe { &a.u_addr.ip6 })),
                 _ => unreachable!(),
             };
@@ -118,7 +118,7 @@ impl From<mdns_result_t> for QueryResult {
 
         let ip_protocol = match result.ip_protocol {
             mdns_ip_protocol_t_MDNS_IP_PROTOCOL_V4 => Protocol::V4,
-            #[cfg(feature = "esp_idf_lwip_ipv6")]
+            #[cfg(esp_idf_lwip_ipv6)]
             mdns_ip_protocol_t_MDNS_IP_PROTOCOL_V6 => Protocol::V6,
             _ => unreachable!(),
         };
@@ -380,7 +380,7 @@ impl EspMdns {
         Ok(from_esp_ip4_addr_t(&addr))
     }
 
-    #[cfg(feature = "esp_idf_lwip_ipv6")]
+    #[cfg(esp_idf_lwip_ipv6)]
     pub fn query_aaaa(
         &self,
         hostname: impl AsRef<str>,
@@ -504,7 +504,7 @@ fn from_esp_ip4_addr_t(addr: &esp_ip4_addr_t) -> Ipv4Addr {
     Ipv4Addr::from(addr.addr.to_le_bytes())
 }
 
-#[cfg(feature = "esp_idf_lwip_ipv6")]
+#[cfg(esp_idf_lwip_ipv6)]
 fn from_esp_ip6_addr_t(addr: &esp_ip6_addr_t) -> Ipv6Addr {
     let mut buf = [0u8; 16];
     let mut i = 0;

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -380,7 +380,7 @@ impl EspMdns {
         Ok(from_esp_ip4_addr_t(&addr))
     }
 
-    #[cfg(feature = enable_ipv6)]
+    #[cfg(feature = "mdns_ipv6")]
     pub fn query_aaaa(
         &self,
         hostname: impl AsRef<str>,

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -9,9 +9,9 @@ use alloc::vec::Vec;
 
 use ::log::info;
 
-use embedded_svc::ipv4::{IpAddr, Ipv4Addr};
 #[cfg(feature = "mdns_ipv6")]
 use embedded_svc::ipv4::Ipv6Addr;
+use embedded_svc::ipv4::{IpAddr, Ipv4Addr};
 
 use crate::sys::*;
 

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 
 use ::log::info;
 
-#[cfg(feature = "mdns_ipv6")]
+#[cfg(feature = "esp_idf_lwip_ipv6")]
 use embedded_svc::ipv4::Ipv6Addr;
 use embedded_svc::ipv4::{IpAddr, Ipv4Addr};
 
@@ -29,14 +29,14 @@ pub enum Interface {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Protocol {
     V4,
-    #[cfg(feature = "mdns_ipv6")]
+    #[cfg(feature = "esp_idf_lwip_ipv6")]
     V6,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Type {
     A = MDNS_TYPE_A as _,
-    #[cfg(feature = "mdns_ipv6")]
+    #[cfg(feature = "esp_idf_lwip_ipv6")]
     AAAA = MDNS_TYPE_AAAA as _,
     ANY = MDNS_TYPE_ANY as _,
     NSEC = MDNS_TYPE_NSEC as _,
@@ -87,7 +87,7 @@ impl From<mdns_result_t> for QueryResult {
             let a = unsafe { (*p).addr };
             let a = match a.type_ as _ {
                 ESP_IPADDR_TYPE_V4 => IpAddr::V4(from_esp_ip4_addr_t(unsafe { &a.u_addr.ip4 })),
-                #[cfg(feature = "mdns_ipv6")]
+                #[cfg(feature = "esp_idf_lwip_ipv6")]
                 ESP_IPADDR_TYPE_V6 => IpAddr::V6(from_esp_ip6_addr_t(unsafe { &a.u_addr.ip6 })),
                 _ => unreachable!(),
             };
@@ -118,7 +118,7 @@ impl From<mdns_result_t> for QueryResult {
 
         let ip_protocol = match result.ip_protocol {
             mdns_ip_protocol_t_MDNS_IP_PROTOCOL_V4 => Protocol::V4,
-            #[cfg(feature = "mdns_ipv6")]
+            #[cfg(feature = "esp_idf_lwip_ipv6")]
             mdns_ip_protocol_t_MDNS_IP_PROTOCOL_V6 => Protocol::V6,
             _ => unreachable!(),
         };
@@ -380,7 +380,7 @@ impl EspMdns {
         Ok(from_esp_ip4_addr_t(&addr))
     }
 
-    #[cfg(feature = "mdns_ipv6")]
+    #[cfg(feature = "esp_idf_lwip_ipv6")]
     pub fn query_aaaa(
         &self,
         hostname: impl AsRef<str>,
@@ -504,7 +504,7 @@ fn from_esp_ip4_addr_t(addr: &esp_ip4_addr_t) -> Ipv4Addr {
     Ipv4Addr::from(addr.addr.to_le_bytes())
 }
 
-#[cfg(feature = "mdns_ipv6")]
+#[cfg(feature = "esp_idf_lwip_ipv6")]
 fn from_esp_ip6_addr_t(addr: &esp_ip6_addr_t) -> Ipv6Addr {
     let mut buf = [0u8; 16];
     let mut i = 0;

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -9,7 +9,9 @@ use alloc::vec::Vec;
 
 use ::log::info;
 
-use embedded_svc::ipv4::{IpAddr, Ipv4Addr, Ipv6Addr};
+use embedded_svc::ipv4::{IpAddr, Ipv4Addr};
+#[cfg(feature = "mdns_ipv6")]
+use embedded_svc::ipv4::Ipv6Addr;
 
 use crate::sys::*;
 
@@ -27,12 +29,14 @@ pub enum Interface {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Protocol {
     V4,
+    #[cfg(feature = "mdns_ipv6")]
     V6,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Type {
     A = MDNS_TYPE_A as _,
+    #[cfg(feature = "mdns_ipv6")]
     AAAA = MDNS_TYPE_AAAA as _,
     ANY = MDNS_TYPE_ANY as _,
     NSEC = MDNS_TYPE_NSEC as _,
@@ -83,6 +87,7 @@ impl From<mdns_result_t> for QueryResult {
             let a = unsafe { (*p).addr };
             let a = match a.type_ as _ {
                 ESP_IPADDR_TYPE_V4 => IpAddr::V4(from_esp_ip4_addr_t(unsafe { &a.u_addr.ip4 })),
+                #[cfg(feature = "mdns_ipv6")]
                 ESP_IPADDR_TYPE_V6 => IpAddr::V6(from_esp_ip6_addr_t(unsafe { &a.u_addr.ip6 })),
                 _ => unreachable!(),
             };
@@ -113,6 +118,7 @@ impl From<mdns_result_t> for QueryResult {
 
         let ip_protocol = match result.ip_protocol {
             mdns_ip_protocol_t_MDNS_IP_PROTOCOL_V4 => Protocol::V4,
+            #[cfg(feature = "mdns_ipv6")]
             mdns_ip_protocol_t_MDNS_IP_PROTOCOL_V6 => Protocol::V6,
             _ => unreachable!(),
         };
@@ -374,6 +380,7 @@ impl EspMdns {
         Ok(from_esp_ip4_addr_t(&addr))
     }
 
+    #[cfg(feature = enable_ipv6)]
     pub fn query_aaaa(
         &self,
         hostname: impl AsRef<str>,
@@ -497,6 +504,7 @@ fn from_esp_ip4_addr_t(addr: &esp_ip4_addr_t) -> Ipv4Addr {
     Ipv4Addr::from(addr.addr.to_le_bytes())
 }
 
+#[cfg(feature = "mdns_ipv6")]
 fn from_esp_ip6_addr_t(addr: &esp_ip6_addr_t) -> Ipv6Addr {
     let mut buf = [0u8; 16];
     let mut i = 0;


### PR DESCRIPTION
Hello,

This is a very ugly hack so you most likely do not want to merge this as is, i'm open to working on any modifications.
The point of the commit is that currently, if ipv6 is disabled in sdkconfig and mdns is imported as an external component in Cargo.toml, the project does not compile because the C functions called by mdns.rs aren't exposed anymore.

Is there a better way to do this? In the meantime, this worked for me.