### PR TITLE
Increase emac_rx stack size

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -1071,7 +1071,7 @@ impl<'d, T> EthDriver<'d, T> {
     fn eth_mac_default_config(_mdc: i32, _mdio: i32) -> eth_mac_config_t {
         eth_mac_config_t {
             sw_reset_timeout_ms: 100,
-            rx_task_stack_size: 2048,
+            rx_task_stack_size: 4096,
             rx_task_prio: 15,
             flags: 0,
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

Currently, on my end, increasing log verbosity beyond info with ethernet enabled crashes with a stack overflow in the emac_rx task. This simply increases the stack size of the task to prevent the crash.

Additionally, this reflects [the default for the esp-idf project](https://github.com/espressif/esp-idf/blob/master/components/esp_eth/include/esp_eth_mac.h#L374C1-L375C1).

Unless i'm mistaken there is no kconfig setting that can be set to move this value.

#### Testing
Tested on my end with log set to debug level, crashes don't occur anymore.