### PR TITLE
Safe wrappers for wifi promiscuous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow using esp timer with skip_unhandled_events (#526)
 - OTA - Implements a new type `EspFirmwareInfoLoad` that has a reduced memory consumption (#531)
 - Added set_promiscuous function in EthDriver (#246)
+- Added set_promiscuous, get_promiscuous functions in WifiDriver (#246)
 
 ### Fixed
 - The alloc::Vec version stomps the scan state from Done to Idle. (#459)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow using esp timer with skip_unhandled_events (#526)
 - OTA - Implements a new type `EspFirmwareInfoLoad` that has a reduced memory consumption (#531)
 - Added set_promiscuous function in EthDriver (#246)
-- Added set_promiscuous, get_promiscuous functions in WifiDriver (#246)
+- Added set_promiscuous, is_promiscuous functions in WifiDriver (#246)
 
 ### Fixed
 - The alloc::Vec version stomps the scan state from Done to Idle. (#459)

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -1032,7 +1032,7 @@ impl<'d, T> EthDriver<'d, T> {
         Ok(())
     }
 
-    /// Enables or disables promiscuous mode for the Ethernet driver.
+    /// Enables or disables promiscuous mode for the [`EthDriver`].
     ///
     /// When promiscuous mode is enabled, the driver captures all Ethernet frames
     /// on the network, regardless of their destination MAC address. This is useful for

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1210,7 +1210,7 @@ impl<'d> WifiDriver<'d> {
     }
 
     /// Gets the state of the promiscuous mode for the [`WifiDriver`].
-    pub fn get_promiscuous(&self) -> Result<bool, EspError> {
+    pub fn is_promiscuous(&self) -> Result<bool, EspError> {
         let mut en: bool = false;
 
         esp!(unsafe { esp_wifi_get_promiscuous(&mut en) })?;

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1192,6 +1192,37 @@ impl<'d> WifiDriver<'d> {
         Ok(())
     }
 
+    /// Enables or disables promiscuous mode for the [`WifiDriver`].
+    ///
+    /// When promiscuous mode is enabled, the driver captures all Wifi frames
+    /// on the network, regardless of their destination MAC address. This is useful for
+    /// debugging or monitoring purposes.
+    pub fn set_promisucous(&mut self, state: bool) -> Result<(), EspError> {
+        esp!(unsafe { esp_wifi_set_promiscuous(state) })?;
+
+        if state {
+            log::info!("Driver set in promiscuous mode");
+        } else {
+            log::info!("Driver set in non-promiscuous mode");
+        }
+
+        Ok(())
+    }
+
+    /// Gets the state of the promiscuous mode for the [`WifiDriver`].
+    pub fn get_promiscuous(&self) -> Result<bool, EspError> {
+        let mut en: bool = false;
+
+        esp!(unsafe { esp_wifi_get_promiscuous(&mut en) })?;
+
+        Ok(en)
+    }
+    
+    //TODO: add safe wrappers for these three functions
+    //https://docs.esp-rs.org/esp-idf-sys/esp_idf_sys/fn.esp_wifi_set_promiscuous_ctrl_filter.html
+    //https://docs.esp-rs.org/esp-idf-sys/esp_idf_sys/fn.esp_wifi_set_promiscuous_filter.html
+    //https://docs.esp-rs.org/esp-idf-sys/esp_idf_sys/fn.esp_wifi_set_promiscuous_rx_cb.html
+
     /// Gets the WPS status as a [`WPS Event`] and disables WPS.
     fn stop_wps(&mut self) -> Result<WpsStatus, EspError> {
         let mut status = self.status.lock();

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1197,7 +1197,7 @@ impl<'d> WifiDriver<'d> {
     /// When promiscuous mode is enabled, the driver captures all Wifi frames
     /// on the network, regardless of their destination MAC address. This is useful for
     /// debugging or monitoring purposes.
-    pub fn set_promisucous(&mut self, state: bool) -> Result<(), EspError> {
+    pub fn set_promiscuous(&mut self, state: bool) -> Result<(), EspError> {
         esp!(unsafe { esp_wifi_set_promiscuous(state) })?;
 
         if state {
@@ -1217,7 +1217,7 @@ impl<'d> WifiDriver<'d> {
 
         Ok(en)
     }
-    
+
     //TODO: add safe wrappers for these three functions
     //https://docs.esp-rs.org/esp-idf-sys/esp_idf_sys/fn.esp_wifi_set_promiscuous_ctrl_filter.html
     //https://docs.esp-rs.org/esp-idf-sys/esp_idf_sys/fn.esp_wifi_set_promiscuous_filter.html


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Second part of #246, adds wrappers for `esp_wifi_get_promiscuous` and `esp_wifi_set_promiscuous`.

If I find the time I'll make wrappers for those three functions in the todo, though for now this fixes #246.

#### Testing
Minimal repo, it works.