### PR TITLE
Add source_ipv4, source_ipv6 functions in EspHttpRawConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OTA - Implements a new type `EspFirmwareInfoLoad` that has a reduced memory consumption (#531)
 - Added set_promiscuous function in EthDriver (#246)
 - Added set_promiscuous, is_promiscuous functions in WifiDriver (#246)
-- Add source_ip4, source_ip6 function in EspHttpRawConnection (#538)
+- Added source_ipv4, source_ipv6 function in EspHttpRawConnection (#538)
 
 ### Fixed
 - The alloc::Vec version stomps the scan state from Done to Idle. (#459)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow using esp timer with skip_unhandled_events (#526)
 - OTA - Implements a new type `EspFirmwareInfoLoad` that has a reduced memory consumption (#531)
 - Added set_promiscuous function in EthDriver (#246)
-- Add source_ip function in EspHttpRawConnection (#538)
+- Add source_ip4, source_ip6 function in EspHttpRawConnection (#538)
 
 ### Fixed
 - The alloc::Vec version stomps the scan state from Done to Idle. (#459)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow using esp timer with skip_unhandled_events (#526)
 - OTA - Implements a new type `EspFirmwareInfoLoad` that has a reduced memory consumption (#531)
 - Added set_promiscuous function in EthDriver (#246)
+- Add source_ip function in EspHttpRawConnection (#538)
 
 ### Fixed
 - The alloc::Vec version stomps the scan state from Done to Idle. (#459)

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -908,11 +908,12 @@ impl EspHttpRawConnection<'_> {
                 return Err(EspError::from(-1).unwrap());
             }
 
-            let ip: Ipv6Addr = CStr::from_ptr(&ip_string as *const [ffi::c_char] as *const ffi::c_char)
-                .to_str()
-                .map_err(|_| EspError::from(-1).unwrap())?
-                .parse()
-                .map_err(|_| EspError::from(-1).unwrap())?;
+            let ip: Ipv6Addr =
+                CStr::from_ptr(&ip_string as *const [ffi::c_char] as *const ffi::c_char)
+                    .to_str()
+                    .map_err(|_| EspError::from(-1).unwrap())?
+                    .parse()
+                    .map_err(|_| EspError::from(-1).unwrap())?;
 
             Ok(ip)
         }

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -35,8 +35,6 @@
 use core::cell::UnsafeCell;
 use core::fmt::Debug;
 use core::marker::PhantomData;
-#[cfg(any(esp_idf_lwip_ipv4, esp_idf_lwip_ipv6))]
-use core::mem;
 #[cfg(esp_idf_lwip_ipv4)]
 use core::net::Ipv4Addr;
 #[cfg(esp_idf_lwip_ipv6)]
@@ -820,14 +818,14 @@ impl EspHttpRawConnection<'_> {
             }
 
             let mut address = sockaddr_in {
-                sin_len: mem::size_of::<sockaddr_in>() as u8,
+                sin_len: core::mem::size_of::<sockaddr_in>() as u8,
                 sin_family: AF_INET as u8,
                 sin_port: 0,
                 sin_addr: in_addr { s_addr: 0 },
                 sin_zero: [0; 8],
             };
 
-            let mut addr_len = mem::size_of::<sockaddr_in>() as socklen_t;
+            let mut addr_len = core::mem::size_of::<sockaddr_in>() as socklen_t;
 
             esp!(lwip_getpeername(
                 sockfd,

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -893,13 +893,14 @@ impl EspHttpRawConnection<'_> {
                 &mut addr_len,
             ))?;
 
+            //We use c_char to be platform independent
             // IPv6 address = 39 bytes + null terminator
             let mut ip_string: [ffi::c_char; 40] = [0; 40];
 
             if lwip_inet_ntop(
                 AF_INET6 as _,
                 &address.sin6_addr as *const _ as *const _,
-                ip_string.as_mut_ptr(),
+                &mut ip_string as *mut [ffi::c_char] as *mut ffi::c_char,
                 ip_string.len() as _,
             )
             .is_null()
@@ -907,7 +908,7 @@ impl EspHttpRawConnection<'_> {
                 return Err(EspError::from(-1).unwrap());
             }
 
-            let ip: Ipv6Addr = CStr::from_ptr(ip_string.as_ptr())
+            let ip: Ipv6Addr = CStr::from_ptr(&ip_string as *const [ffi::c_char] as *const ffi::c_char)
                 .to_str()
                 .map_err(|_| EspError::from(-1).unwrap())?
                 .parse()

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -873,7 +873,7 @@ impl EspHttpRawConnection<'_> {
             }
 
             let mut address = sockaddr_in6 {
-                sin6_len: mem::size_of::<sockaddr_in6>() as u8,
+                sin6_len: core::mem::size_of::<sockaddr_in6>() as u8,
                 sin6_family: AF_INET6 as u8,
                 sin6_port: 0,
                 sin6_addr: in6_addr {
@@ -883,7 +883,7 @@ impl EspHttpRawConnection<'_> {
                 sin6_scope_id: 0,
             };
 
-            let mut addr_len = mem::size_of::<sockaddr_in6>() as socklen_t;
+            let mut addr_len = core::mem::size_of::<sockaddr_in6>() as socklen_t;
 
             esp!(lwip_getpeername(
                 sockfd,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
My attempt at #538. It works flawlessly on my end. 
#### Testing
```rust
    http_server.fn_handler("/", Method::Get, {
        move |mut request| {
            let html = "hello world";

            let connection = request.connection();

            log::info!("SOURCE IP: {}", connection.raw_connection()?.source_ip()?);

            connection.initiate_response(200, Some("OK"), &[("Content-Type", "text/html")])?;

            connection.write(html.as_bytes())?;

            Ok::<(), Error>(())
        }
    })?;
```

```
I (00:00:10.545) esp_netif_lwip: DHCP server assigned IP to a client, IP is: 192.168.100.2
I (00:00:12.947) charizhard::http: SOURCE IP: 192.168.100.2
```
fixes #538 