### PR TITLE
Blocking and buffered StdIo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OTA - Implements a new type `EspFirmwareInfoLoad` that has a reduced memory consumption (#531)
 - Added set_promiscuous function in EthDriver (#246)
 - Added set_promiscuous, is_promiscuous functions in WifiDriver (#246)
+- Blocking and buffered StdIo (#541) - i.e. easy reading/input from `std::io::stdin`
 
 ### Fixed
 - The alloc::Vec version stomps the scan state from Done to Idle. (#459)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [v] I have updated existing examples or added new ones (if applicable).
- [v] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [v] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [v] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

A new type, `esp_idf_svc::io::vfs::BlockingStdIo` that allows the user to switch to buffered and blocking IO for the Rust `std::io::stdout`, `std::io::stderr` and most importantly, `std::io::stdin`, whereas this allows for an ergonomic, buffered input via `std::io::stdio`.

Switching can be done via either UART or (for the MCUs that do support it) the USB-serial-jtag peripheral.