### PR TITLE
Fix crash when enabling napt

### DIFF
--- a/src/netif.rs
+++ b/src/netif.rs
@@ -599,18 +599,16 @@ impl EspNetif {
         Ok(())
     }
 
+    #[cfg(esp_idf_lwip_ipv4_napt)]
     unsafe extern "C" fn napt_wrapper(ctx: *mut ffi::c_void) {
-        #[cfg(esp_idf_lwip_ipv4_napt)]
-        {
-            let ctx = unsafe { *(ctx as *mut (u8, i32)) };
+        let ctx = unsafe { *(ctx as *mut (u8, i32)) };
 
-            ip_napt_enable_no(ctx.0, ctx.1);
-        }
+        ip_napt_enable_no(ctx.0, ctx.1);
     }
 
     /// Enables or disables NAPT on this netif.
     ///
-    /// Enable operation can be performed only on one interface at a time.
+    /// Enable operation can be performed only on one interface at a time. 
     /// NAPT cannot be enabled on multiple interfaces according to this implementation.
     #[cfg(esp_idf_lwip_ipv4_napt)]
     pub fn enable_napt(&mut self, enable: bool) -> Result<(), EspError> {

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -608,7 +608,7 @@ impl EspNetif {
 
     /// Enables or disables NAPT on this netif.
     ///
-    /// Enable operation can be performed only on one interface at a time. 
+    /// Enable operation can be performed only on one interface at a time.
     /// NAPT cannot be enabled on multiple interfaces according to this implementation.
     #[cfg(esp_idf_lwip_ipv4_napt)]
     pub fn enable_napt(&mut self, enable: bool) -> Result<(), EspError> {
@@ -619,7 +619,7 @@ impl EspNetif {
             );
 
             esp!(esp_netif_tcpip_exec(
-                Some(napt_wrapper),
+                Some(EspNetif::napt_wrapper),
                 &ctx as *const _ as *mut _
             ))?;
 

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -600,13 +600,18 @@ impl EspNetif {
     }
 
     #[cfg(esp_idf_lwip_ipv4_napt)]
-    pub fn enable_napt(&mut self, enable: bool) {
+    pub fn enable_napt(&mut self, enable: bool) -> Result<(), EspError> {
         unsafe {
-            crate::sys::ip_napt_enable_no(
-                (esp_netif_get_netif_impl_index(self.handle) - 1) as u8,
-                if enable { 1 } else { 0 },
-            )
-        };
+            let if_index = (esp_netif_get_netif_impl_index(self.handle) - 1) as u8;
+            let ctx = (if_index, if enable { 1 } else { 0 });
+
+            esp!(esp_netif_tcpip_exec(
+                Some(ip_napt_enable_no),
+                &ctx as *const _ as *mut _
+            ));
+
+            Ok(())
+        }
     }
 }
 

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -599,16 +599,18 @@ impl EspNetif {
         Ok(())
     }
 
-    #[cfg(esp_idf_lwip_ipv4_napt)]
     unsafe extern "C" fn napt_wrapper(ctx: *mut ffi::c_void) {
-        let ctx = unsafe { *(ctx as *mut (u8, i32)) };
+        #[cfg(esp_idf_lwip_ipv4_napt)]
+        {
+            let ctx = unsafe { *(ctx as *mut (u8, i32)) };
 
-        ip_napt_enable_no(ctx.0, ctx.1);
+            ip_napt_enable_no(ctx.0, ctx.1);
+        }
     }
 
     /// Enables or disables NAPT on this netif.
     ///
-    /// Enable operation can be performed only on one interface at a time. 
+    /// Enable operation can be performed only on one interface at a time.
     /// NAPT cannot be enabled on multiple interfaces according to this implementation.
     #[cfg(esp_idf_lwip_ipv4_napt)]
     pub fn enable_napt(&mut self, enable: bool) -> Result<(), EspError> {

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -605,11 +605,18 @@ impl EspNetif {
 
         ip_napt_enable_no(ctx.0, ctx.1);
     }
-    
+
+    /// Enables or disables NAPT on this netif.
+    ///
+    /// Enable operation can be performed only on one interface at a time. 
+    /// NAPT cannot be enabled on multiple interfaces according to this implementation.
     #[cfg(esp_idf_lwip_ipv4_napt)]
     pub fn enable_napt(&mut self, enable: bool) -> Result<(), EspError> {
         unsafe {
-            let ctx = ((esp_netif_get_netif_impl_index(self.handle) - 1) as u8, if enable { 1 } else { 0 });
+            let ctx = (
+                (esp_netif_get_netif_impl_index(self.handle) - 1) as u8,
+                if enable { 1 } else { 0 },
+            );
 
             esp!(esp_netif_tcpip_exec(
                 Some(napt_wrapper),

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -600,10 +600,12 @@ impl EspNetif {
     }
 
     #[cfg(esp_idf_lwip_ipv4_napt)]
-    unsafe extern "C" fn napt_wrapper(ctx: *mut ffi::c_void) {
+    unsafe extern "C" fn napt_wrapper(ctx: *mut ffi::c_void) -> i32 {
         let ctx = unsafe { *(ctx as *mut (u8, i32)) };
 
         ip_napt_enable_no(ctx.0, ctx.1);
+
+        0 
     }
 
     /// Enables or disables NAPT on this netif.


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
something something tcpip context else i crash.

I added some documentation as well. Really a paste from the wiki. There might be a way to do this cleaner but I could not for the life of me figure it out. The enable function takes two arguments so I can't really pass them directly I have to do this whole spaghetti thing. Let me know if you find an easier way i'll modify it.

#### Testing
It's not crashing.