### PR TITLE
Fix ambiguous name error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix ambiguous name error (a compilation issue when the NimBLE component is enabled in esp-idf-sys)
+
 ## [0.50.0] - 2025-01-02
 
 ### Deprecated

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -1047,9 +1047,9 @@ impl<'d, T> EthDriver<'d, T> {
         })?;
 
         if state {
-            log::info!("Driver set in promiscuous mode");
+            info!("Driver set in promiscuous mode");
         } else {
-            log::info!("Driver set in non-promiscuous mode");
+            info!("Driver set in non-promiscuous mode");
         }
 
         Ok(())

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -1201,9 +1201,9 @@ impl<'d> WifiDriver<'d> {
         esp!(unsafe { esp_wifi_set_promiscuous(state) })?;
 
         if state {
-            log::info!("Driver set in promiscuous mode");
+            info!("Driver set in promiscuous mode");
         } else {
-            log::info!("Driver set in non-promiscuous mode");
+            info!("Driver set in non-promiscuous mode");
         }
 
         Ok(())


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
When NimBLE is enabled, the following error occurs.

```
error[E0433]: failed to resolve: `log` is a struct, not a module
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/eth.rs:1050:13
     |
1050 |             log::info!("Driver set in promiscuous mode");
     |             ^^^ `log` is a struct, not a module

error[E0433]: failed to resolve: `log` is a struct, not a module
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/eth.rs:1052:13
     |
1052 |             log::info!("Driver set in non-promiscuous mode");
     |             ^^^ `log` is a struct, not a module

error[E0433]: failed to resolve: `log` is a struct, not a module
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/wifi.rs:1204:13
     |
1204 |             log::info!("Driver set in promiscuous mode");
     |             ^^^ `log` is a struct, not a module

error[E0433]: failed to resolve: `log` is a struct, not a module
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/wifi.rs:1206:13
     |
1206 |             log::info!("Driver set in non-promiscuous mode");
     |             ^^^ `log` is a struct, not a module

error[E0659]: `log` is ambiguous
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/eth.rs:1050:13
     |
1050 |             log::info!("Driver set in promiscuous mode");
     |             ^^^ ambiguous name
     |
     = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
     = note: `log` could refer to a crate passed with `--extern`
     = help: use `::log` to refer to this crate unambiguously
note: `log` could also refer to the struct imported here
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/eth.rs:32:5
     |
32   | use crate::sys::*;
     |     ^^^^^^^^^^^^^
     = help: consider adding an explicit import of `log` to disambiguate
     = help: or use `self::log` to refer to this struct unambiguously

error[E0659]: `log` is ambiguous
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/eth.rs:1052:13
     |
1052 |             log::info!("Driver set in non-promiscuous mode");
     |             ^^^ ambiguous name
     |
     = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
     = note: `log` could refer to a crate passed with `--extern`
     = help: use `::log` to refer to this crate unambiguously
note: `log` could also refer to the struct imported here
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/eth.rs:32:5
     |
32   | use crate::sys::*;
     |     ^^^^^^^^^^^^^
     = help: consider adding an explicit import of `log` to disambiguate
     = help: or use `self::log` to refer to this struct unambiguously

error[E0659]: `log` is ambiguous
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/wifi.rs:1204:13
     |
1204 |             log::info!("Driver set in promiscuous mode");
     |             ^^^ ambiguous name
     |
     = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
     = note: `log` could refer to a crate passed with `--extern`
     = help: use `::log` to refer to this crate unambiguously
note: `log` could also refer to the struct imported here
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/wifi.rs:20:5
     |
20   | use crate::sys::*;
     |     ^^^^^^^^^^^^^
     = help: consider adding an explicit import of `log` to disambiguate
     = help: or use `self::log` to refer to this struct unambiguously

error[E0659]: `log` is ambiguous
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/wifi.rs:1206:13
     |
1206 |             log::info!("Driver set in non-promiscuous mode");
     |             ^^^ ambiguous name
     |
     = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
     = note: `log` could refer to a crate passed with `--extern`
     = help: use `::log` to refer to this crate unambiguously
note: `log` could also refer to the struct imported here
    --> /home/a/.cargo/registry/src/index.crates.io-6f17d22bba15001f/esp-idf-svc-0.50.0/src/wifi.rs:20:5
     |
20   | use crate::sys::*;
     |     ^^^^^^^^^^^^^
     = help: consider adding an explicit import of `log` to disambiguate
     = help: or use `self::log` to refer to this struct unambiguously
```