### PR TITLE
embassy-time-driver V0.2 impl

### DIFF
--- a/.github/configs/sdkconfig.defaults
+++ b/.github/configs/sdkconfig.defaults
@@ -2,6 +2,7 @@ CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=y
 
 # Examples often require a larger than the default stack size for the main thread and for the sysloop event task.
+CONFIG_ESP_TIMER_TASK_STACK_SIZE=4096 # Necessary when the `embassy-time-driver` feature is enabled
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=20000
 CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=8192
 CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=8192

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Breaking
+- New `embassy-time-driver` implementation compatible with `embassy-time-driver` V0.2 (#548)
+
 ### Added
 - New example, `wifi_dhcp_with_hostname` to demonstrate setting a custom hostname when establishing a DHCP connection
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ harness = false
 default = ["std", "binstart"]
 
 std = ["alloc", "log/std", "esp-idf-hal/std", "embedded-svc/std", "futures-io"]
+embassy-time-driver = ["dep:embassy-time-driver", "embassy-time-queue-utils"]
 alloc = ["esp-idf-hal/alloc", "embedded-svc/alloc", "uncased/alloc"]
 nightly = ["embedded-svc/nightly", "esp-idf-hal/nightly"]
 experimental = ["embedded-svc/experimental", "esp-idf-hal/experimental"]
@@ -48,7 +49,8 @@ uncased = { version = "0.9.7", default-features = false }
 embedded-hal-async = { version = "1", default-features = false }
 embedded-svc = { version = "0.28", default-features = false }
 esp-idf-hal = { version = "0.45", default-features = false }
-embassy-time-driver = { version = "0.1", optional = true, features = ["tick-hz-1_000_000"] }
+embassy-time-driver = { version = "0.2", optional = true, features = ["tick-hz-1_000_000"] }
+embassy-time-queue-utils = { version = "0.1", optional = true }
 embassy-futures = "0.1"
 embedded-storage = { version = "0.3", optional = true }
 futures-io = { version = "0.3", optional = true }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -378,134 +378,132 @@ mod isr {
     }
 }
 
+/// This module is used to provide a time driver for the `embassy-time` crate.
+///
+/// The minimum provided resolution is ~ 20-30us when the CPU is at top speed of 240MHz
+/// (https://docs.espressif.com/projects/esp-idf/en/v5.4/esp32/api-reference/system/esp_timer.html#timeout-value-limits)
+///
+/// The tick-rate is 1MHz (i.e. 1 tick is 1us).
 #[cfg(feature = "embassy-time-driver")]
 pub mod embassy_time_driver {
-    use core::cell::UnsafeCell;
+    use core::cell::RefCell;
+    use core::task::Waker;
 
-    use heapless::Vec;
+    use ::embassy_time_driver::Driver;
+    use embassy_time_queue_utils::Queue;
 
-    use ::embassy_time_driver::{AlarmHandle, Driver};
-
-    use crate::hal::task::CriticalSection;
-
-    use crate::sys::*;
-
+    use crate::private::mutex::Mutex;
     use crate::timer::*;
 
-    struct Alarm {
+    struct EspDriverInner {
+        queue: embassy_time_queue_utils::Queue,
         timer: Option<EspTimer<'static>>,
-        #[allow(clippy::type_complexity)]
-        callback: Option<(fn(*mut ()), *mut ())>,
     }
 
-    struct EspDriver<const MAX_ALARMS: usize = 16> {
-        alarms: UnsafeCell<Vec<Alarm, MAX_ALARMS>>,
-        cs: CriticalSection,
-    }
-
-    impl<const MAX_ALARMS: usize> EspDriver<MAX_ALARMS> {
-        const fn new() -> Self {
-            Self {
-                alarms: UnsafeCell::new(Vec::new()),
-                cs: CriticalSection::new(),
-            }
-        }
-
-        fn call(&self, id: u8) {
-            let callback = {
-                let _guard = self.cs.enter();
-
-                let alarm = self.alarm(id);
-
-                alarm.callback
-            };
-
-            if let Some((func, arg)) = callback {
-                func(arg)
-            }
-        }
-
-        #[allow(clippy::mut_from_ref)]
-        fn alarm(&self, id: u8) -> &mut Alarm {
-            &mut unsafe { self.alarms.get().as_mut() }.unwrap()[id as usize]
-        }
-    }
-
-    unsafe impl<const MAX_ALARMS: usize> Send for EspDriver<MAX_ALARMS> {}
-    unsafe impl<const MAX_ALARMS: usize> Sync for EspDriver<MAX_ALARMS> {}
-
-    impl<const MAX_ALARMS: usize> Driver for EspDriver<MAX_ALARMS> {
-        fn now(&self) -> u64 {
+    impl EspDriverInner {
+        fn now() -> u64 {
             unsafe { esp_timer_get_time() as _ }
         }
 
-        unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {
-            let id = {
-                let _guard = self.cs.enter();
+        fn schedule_next_expiration(&mut self) {
+            /// End of epoch minus one day
+            const MAX_SAFE_TIMEOUT_US: u64 = u64::MAX - 24 * 60 * 60 * 1000 * 1000;
 
-                let id = self.alarms.get().as_mut().unwrap().len();
+            let timer = self.timer.as_mut().unwrap();
 
-                if id < MAX_ALARMS {
-                    self.alarms
-                        .get()
-                        .as_mut()
-                        .unwrap()
-                        .push(Alarm {
-                            timer: None,
-                            callback: None,
-                        })
-                        .unwrap_or_else(|_| unreachable!());
+            loop {
+                let now = Self::now();
+                let next_at = self.queue.next_expiration(now);
 
-                    id as u8
-                } else {
-                    return None;
+                if now < next_at {
+                    let after = next_at - now;
+
+                    if after <= MAX_SAFE_TIMEOUT_US {
+                        // Why?
+                        // The ESP-IDF Timer API does not have a `Timer::at` method so we have to call it with
+                        // `Timer::after(next_at - now)` instead. The problem is - even though the ESP IDF
+                        // Timer API does not have a `Timer::at` method - _internally_ it takes our `next_at - now`,
+                        // adds to it a **newer** "now" and sets this as the moment in time when the timer should trigger.
+                        //
+                        // Consider what would happen if we call `Timer::after(u64::MAX - now)`:
+                        // The result would be something like `u64::MAX - now + (now + 1)` which would silently overflow and
+                        // trigger the timer after 1us:
+                        // https://github.com/espressif/esp-idf/blob/b5ac4fbdf9e9fb320bb0a98ee4fbaa18f8566f37/components/esp_timer/src/esp_timer.c#L188
+                        //
+                        // To workaround this problem, we make sure to never call `Timer::after(ms)` with `ms` greater than `MAX_SAFE_TIMEOUT_US`
+                        // (i.e. the end of epoch - one day).
+                        //
+                        // Thus, even if we are un-scheduled between the calculation of our own `now` and the driver's newer `now`,
+                        // there is one extra **day** of millis to accomodate for the potential overflow. If the overflow does happen still
+                        // (which is kinda unthinkable given the time scales we are working with), the timer will re-trigger immediately,
+                        // but hopefully on the next (or next after next and so on) re-trigger, we won't have the overflow anymore.
+                        timer.after(Duration::from_micros(after)).unwrap();
+                    }
+
+                    break;
                 }
-            };
-
-            let service = EspTimerService::<Task>::new().unwrap();
-
-            // Driver is always statically allocated, so this is safe
-            let static_self: &'static Self = core::mem::transmute(self);
-
-            self.alarm(id).timer = Some(service.timer(move || static_self.call(id)).unwrap());
-
-            Some(AlarmHandle::new(id))
-        }
-
-        fn set_alarm_callback(&self, handle: AlarmHandle, callback: fn(*mut ()), ctx: *mut ()) {
-            let _guard = self.cs.enter();
-
-            let alarm = self.alarm(handle.id());
-
-            alarm.callback = Some((callback, ctx));
-        }
-
-        fn set_alarm(&self, handle: AlarmHandle, timestamp: u64) -> bool {
-            let alarm = self.alarm(handle.id());
-
-            let now = self.now();
-
-            if now < timestamp {
-                alarm
-                    .timer
-                    .as_mut()
-                    .unwrap()
-                    .after(Duration::from_micros(timestamp - now))
-                    .unwrap();
-                true
-            } else {
-                false
             }
         }
     }
 
-    pub type LinkWorkaround = [*mut (); 4];
+    struct EspDriver {
+        inner: Mutex<RefCell<EspDriverInner>>,
+    }
 
+    impl EspDriver {
+        const fn new() -> Self {
+            Self {
+                inner: Mutex::new(RefCell::new(EspDriverInner {
+                    queue: Queue::new(),
+                    timer: None,
+                })),
+            }
+        }
+    }
+
+    unsafe impl Send for EspDriver {}
+    unsafe impl Sync for EspDriver {}
+
+    impl Driver for EspDriver {
+        fn now(&self) -> u64 {
+            EspDriverInner::now()
+        }
+
+        fn schedule_wake(&self, at: u64, waker: &Waker) {
+            let service = EspTimerService::<Task>::new().unwrap();
+
+            let guard = self.inner.lock();
+            let mut inner = guard.borrow_mut();
+
+            if inner.timer.is_none() {
+                // Driver is always statically allocated, so this is safe
+                let static_self: &'static Self = unsafe { core::mem::transmute(self) };
+
+                inner.timer = Some(
+                    service
+                        .timer(move || {
+                            static_self
+                                .inner
+                                .lock()
+                                .borrow_mut()
+                                .schedule_next_expiration()
+                        })
+                        .unwrap(),
+                );
+            }
+
+            if inner.queue.schedule_wake(at, waker) {
+                inner.schedule_next_expiration();
+            }
+        }
+    }
+
+    pub type LinkWorkaround = [*mut (); 2];
+
+    #[used]
     static mut __INTERNAL_REFERENCE: LinkWorkaround = [
         _embassy_time_now as *mut _,
-        _embassy_time_allocate_alarm as *mut _,
-        _embassy_time_set_alarm_callback as *mut _,
-        _embassy_time_set_alarm as *mut _,
+        _embassy_time_schedule_wake as *mut _,
     ];
 
     pub fn link() -> LinkWorkaround {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [v] I have updated existing examples or added new ones (if applicable).
- [v] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [v] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [v] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
An `embassy-time-driver` implementation compatible with the just-released backwards-incompatible `embassy-time-driver` V0.2.

#### Testing

With a custom example that unfortunately cannot be pushed, or else `esp-idf-svc` would non-optionally depend on `embassy-time`, which is not ideal.
