### PR TITLE
Expose `embedded-svc/use_serde` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - OTA: New method - `EspFirmwareInfoLoad::fetch_native` - returning the full native ESP-IDF image descriptor structures
+- Added `use_serde` feature, which enables the `use_serde` feature of `embedded-svc` crate, allowing to deserialize configuration structs.
 
 ## [0.51.0] - 2025-01-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ panic_handler = ["esp-idf-hal/panic_handler"]
 binstart = ["esp-idf-hal/binstart"]
 libstart = ["esp-idf-hal/libstart"]
 
+# Propagated form embeded-svc
+use_serde = ["embedded-svc/use_serde"]
+
 [dependencies]
 heapless = { version = "0.8", default-features = false }
 num_enum = { version = "0.7", default-features = false }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
The `embedded-svc` crate have a `use_serde` feature, which is not enabled by default. To enable it, it have to be propagated from this crate.

This feature is handy when dealing with configuration. In my use case, I use it to parse to have a simple json file for my wifi configuration.

#### Testing
It's a simple cargo feature flag.