### PR TITLE
Implement MQTT outbox limits and get_outbox_size()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - OTA: New method - `EspFirmwareInfoLoad::fetch_native` - returning the full native ESP-IDF image descriptor structures
 - Added `use_serde` feature, which enables the `use_serde` feature of `embedded-svc` crate, allowing to deserialize configuration structs.
+- Implement MQTT outbox limit and get_outbox_size()
 
 ## [0.51.0] - 2025-01-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+- Implement MQTT outbox limit and get_outbox_size()
+
 ### Fixed
 - Fix wrong BT configuration version on the c6 (issue #556)
 
 ### Added
 - OTA: New method - `EspFirmwareInfoLoad::fetch_native` - returning the full native ESP-IDF image descriptor structures
 - Added `use_serde` feature, which enables the `use_serde` feature of `embedded-svc` crate, allowing to deserialize configuration structs.
-- Implement MQTT outbox limit and get_outbox_size()
 
 ## [0.51.0] - 2025-01-15
 

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -625,6 +625,10 @@ impl<'a> EspMqttClient<'a> {
         Self::check(unsafe { esp_mqtt_client_set_uri(self.raw_client, uri.as_ptr()) })
     }
 
+    pub fn get_outbox_size(&self) -> i32 {
+        unsafe { esp_mqtt_client_get_outbox_size(self.raw_client) }
+    }
+
     extern "C" fn handle(
         event_handler_arg: *mut c_void,
         _event_base: esp_event_base_t,

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -67,6 +67,7 @@ pub struct MqttClientConfiguration<'a> {
     pub task_stack: usize,
     pub buffer_size: usize,
     pub out_buffer_size: usize,
+    pub outbox_limit: u64,
 
     pub username: Option<&'a str>,
     pub password: Option<&'a str>,
@@ -108,6 +109,7 @@ impl Default for MqttClientConfiguration<'_> {
             task_stack: 0,
             buffer_size: 0,
             out_buffer_size: 0,
+            outbox_limit: 0,
 
             username: None,
             password: None,
@@ -269,6 +271,9 @@ impl<'a> TryFrom<&'a MqttClientConfiguration<'a>>
                 size: conf.buffer_size as _,
                 out_size: conf.out_buffer_size as _,
                 ..Default::default()
+            },
+            outbox: esp_mqtt_client_config_t_outbox_config_t {
+                limit: conf.outbox_limit,
             },
             ..Default::default()
         };

--- a/src/mqtt/client.rs
+++ b/src/mqtt/client.rs
@@ -67,7 +67,7 @@ pub struct MqttClientConfiguration<'a> {
     pub task_stack: usize,
     pub buffer_size: usize,
     pub out_buffer_size: usize,
-    pub outbox_limit: u64,
+    pub outbox_limit: Option<u64>,
 
     pub username: Option<&'a str>,
     pub password: Option<&'a str>,
@@ -109,7 +109,7 @@ impl Default for MqttClientConfiguration<'_> {
             task_stack: 0,
             buffer_size: 0,
             out_buffer_size: 0,
-            outbox_limit: 0,
+            outbox_limit: None,
 
             username: None,
             password: None,
@@ -272,9 +272,6 @@ impl<'a> TryFrom<&'a MqttClientConfiguration<'a>>
                 out_size: conf.out_buffer_size as _,
                 ..Default::default()
             },
-            outbox: esp_mqtt_client_config_t_outbox_config_t {
-                limit: conf.outbox_limit,
-            },
             ..Default::default()
         };
 
@@ -319,6 +316,10 @@ impl<'a> TryFrom<&'a MqttClientConfiguration<'a>>
                 c_conf.credentials.authentication.key_password = pass.as_ptr() as _;
                 c_conf.credentials.authentication.key_password_len = pass.len() as _;
             }
+        }
+
+        if let Some(outbox_limit) = conf.outbox_limit {
+            c_conf.outbox.limit = outbox_limit;
         }
 
         #[cfg(all(esp_idf_esp_tls_psk_verification, feature = "alloc"))]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [X] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [X] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [X] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
This change implements get_outbox_size() on the EspMqttClient to retrieve the amount of bytes currently stored in the MQTT outbox.
Additionally implement a configurable option in MqttClientConfiguration to limit the outbox size to the given amount of bytes so there is no ever growing outbox size that might fill up the entire RAM.

#### Testing
I tested the limit with this configuration and sent a a lot of bytes
```
        &MqttClientConfiguration {
            client_id: Some(client_id),
            username,
            password,
            outbox_limit: Some(5000),
            ..Default::default()
        },
```
and tested it with
```
    if client.get_outbox_size() > 5100 {
        error!("too much in the outbox, ignore this message");
    } 
```
The message is shown if no limit is configured and does not show up once a limit of 5000 is set.

```
            match client.enqueue(
                &topic,
                esp_idf_svc::mqtt::client::QoS::AtLeastOnce,
                false,
                value.as_bytes(),
            ) {
                Ok(message_id) => debug!("enqueued {topic:?} = {value} ({message_id})"),
                Err(error) => error!("cannot enqueue mqtt message: {error}"),
            }
```

This returns `cannot enqueue mqtt message: ERROR` if the outbox is full.