### PR TITLE
Allow specifying known flash size during OTA to make erasing faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - OTA: New method - `EspFirmwareInfoLoad::fetch_native` - returning the full native ESP-IDF image descriptor structures
 - Added `use_serde` feature, which enables the `use_serde` feature of `embedded-svc` crate, allowing to deserialize configuration structs.
+- OTA: Allow specifying image size to speed up erase
 
 ## [0.51.0] - 2025-01-15
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
The OTA process requires first erasing data in the flash partition and then writing the new image. By default the entire image is erased, even though we only need to erase enough space to fit the image. For esp32s with large flash sizes and relatively small images, the erasing can dominate total OTA time.

This PR adds an `initiate_update_with_known_size` variant to allow passing through the size parameter to the underlying ESP IDF library rather than the default `OTA_SIZE_UNKNOWN`.

#### Testing
I tested by using by specifying the size when performing an OTA. For me, this sped up the erase portion of OTA by 3x. (esp32s3 with 32M flash, two 8M OTA partitions, actual image considerably smaller than that)