### PR TITLE
Exposes WS subprotocol in EspHttpServer::ws_handler()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 - Implement MQTT outbox limit and get_outbox_size()
+- Added argument `subprotocol_list` to `ws_handler` to allow subprotocols to be supported by WebSockets
 
 ### Fixed
 - Fix wrong BT configuration version on the c6 (issue #556)

--- a/examples/http_ws_server.rs
+++ b/examples/http_ws_server.rs
@@ -134,7 +134,7 @@ fn main() -> anyhow::Result<()> {
 
     let guessing_games = Mutex::new(BTreeMap::<i32, GuessingGame>::new());
 
-    server.ws_handler("/ws/guess", move |ws| {
+    server.ws_handler("/ws/guess", None, move |ws| {
         let mut sessions = guessing_games.lock().unwrap();
         if ws.is_new() {
             sessions.insert(ws.session(), GuessingGame::new((rand() % 100) + 1));

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1575,19 +1575,31 @@ pub mod ws {
         /// made to that URI, receiving a different `EspHttpWsConnection` each
         /// call.
         ///
+        /// # Arguments
+        ///
+        /// * `uri` - The URI to connect to
+        /// * `subprotocol_list` - An optional string slice containing a comma-separated
+        ///   list of subprotocols to be supported by this handler
+        /// * handler: the handler
+        ///
         /// Note that Websockets functionality is gated behind an SDK flag.
         /// See [`crate::ws`](esp-idf-svc::ws)
-        pub fn ws_handler<H, E>(&mut self, uri: &str, handler: H) -> Result<&mut Self, EspError>
+        pub fn ws_handler<H, E>(
+            &mut self,
+            uri: &str,
+            subprotocol_list: Option<&str>,
+            handler: H,
+        ) -> Result<&mut Self, EspError>
         where
             H: for<'r> Fn(&'r mut EspHttpWsConnection) -> Result<(), E> + Send + Sync + 'a,
             E: Debug,
         {
-            let c_str = to_cstring_arg(uri)?;
+            let uri_c_str = to_cstring_arg(uri)?;
 
             let (req_handler, close_handler) = self.to_native_ws_handler(self.sd, handler);
 
-            let conf = httpd_uri_t {
-                uri: c_str.as_ptr() as _,
+            let mut conf = httpd_uri_t {
+                uri: uri_c_str.as_ptr() as _,
                 method: Newtype::<ffi::c_uint>::from(Method::Get).0,
                 user_ctx: Box::into_raw(Box::new(req_handler)) as *mut _,
                 handler: Some(EspHttpServer::handle_req),
@@ -1595,6 +1607,12 @@ pub mod ws {
                 // TODO: Expose as a parameter in future: handle_ws_control_frames: true,
                 ..Default::default()
             };
+
+            let subproto_c_str; // SAFETY: same scope as httpd_register_uri_handler required!
+            if let Some(subprotocol_list) = subprotocol_list {
+                subproto_c_str = to_cstring_arg(subprotocol_list)?;
+                conf.supported_subprotocol = subproto_c_str.as_ptr();
+            }
 
             esp!(unsafe { crate::sys::httpd_register_uri_handler(self.sd, &conf) })?;
 
@@ -1611,10 +1629,10 @@ pub mod ws {
 
             info!(
                 "Registered Httpd server WS handler for URI \"{}\"",
-                c_str.to_str().unwrap()
+                uri_c_str.to_str().unwrap()
             );
 
-            self.registrations.push((c_str, conf));
+            self.registrations.push((uri_c_str, conf));
 
             Ok(self)
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖
Added argument `subprotocol_list` to `EspHttpServer::ws_handler` to allow subprotocols to be supported by server-side WebSockets.

#### Description
Websockets in reality often rely on subprotocols (Sec-WebSocket-Protocol). The underlying C code supports WebSocket subprotocols, but the Rust layer obviously does not. This PR exposes the attribute `supported_subprotocol´ of the struct `http_ui` to the handler. The added argument is an optional, comma-separated list of sub-protocols. The attribute is only updated, if the supplied Option is not None.

#### Testing
I tested against a custom client that requires the use of a subprotocol. The tests have been carried out on a M5Stack Core2 v1.1 using the "esp" toolchain.