### PR TITLE
Compile MountedLittlefs only if experimental is enabled

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -155,13 +155,21 @@ pub mod vfs {
     }
 
     /// Represents a mounted Littlefs filesystem.
-    #[cfg(all(feature = "alloc", esp_idf_comp_joltwallet__littlefs_enabled))]
+    #[cfg(all(
+        feature = "experimental",
+        feature = "alloc",
+        esp_idf_comp_joltwallet__littlefs_enabled
+    ))]
     pub struct MountedLittlefs<T> {
         _littlefs: T,
         partition_raw_data: crate::fs::littlefs::PartitionRawData,
     }
 
-    #[cfg(all(feature = "alloc", esp_idf_comp_joltwallet__littlefs_enabled))]
+    #[cfg(all(
+        feature = "experimental",
+        feature = "alloc",
+        esp_idf_comp_joltwallet__littlefs_enabled
+    ))]
     impl<T> MountedLittlefs<T> {
         /// Mount a Littlefs filesystem.
         ///
@@ -248,7 +256,11 @@ pub mod vfs {
         }
     }
 
-    #[cfg(all(feature = "alloc", esp_idf_comp_joltwallet__littlefs_enabled))]
+    #[cfg(all(
+        feature = "experimental",
+        feature = "alloc",
+        esp_idf_comp_joltwallet__littlefs_enabled
+    ))]
     impl<T> Drop for MountedLittlefs<T> {
         fn drop(&mut self) {
             use crate::fs::littlefs::PartitionRawData;


### PR DESCRIPTION
### Submission Checklist 📝
This a minor patch to fix broken compilation under some conditions.

### Pull Request Details 📖

#### Description
`crate::fs` is only compiled when the `experimental` feature is enabled, but the user may have started using the `joltwallet/littlefs` component through its raw bindings, without relying on `experimental`.
But `esp_idf_comp_joltwallet__littlefs_enabled` would be true, causing `MountedLittlefs` to be compiled even when `crate::fs` isn't. `crate::fs::littlefs::PartitionRawData` can't be unresolved and breaks the build.

#### Testing
I'm using a local repo of esp-idf-svc as a path dependency.