### PR TITLE
Exposed set_ip_info (and dhcpc start/stop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OTA: New method - `EspFirmwareInfoLoad::fetch_native` - returning the full native ESP-IDF image descriptor structures
 - Added `use_serde` feature, which enables the `use_serde` feature of `embedded-svc` crate, allowing to deserialize configuration structs.
 - OTA: Allow specifying image size to speed up erase
+- Exposed esp_netif_set_ip_info via set_ip_info (similar to get_ip_info) to allow the driver to use a static IP address.
 
 ## [0.51.0] - 2025-01-15
 

--- a/src/netif.rs
+++ b/src/netif.rs
@@ -479,6 +479,30 @@ impl EspNetif {
         }
     }
 
+    pub fn stop_dhcpc(&self) -> Result<(), EspError> {
+        unsafe {
+            esp!(esp_netif_dhcpc_stop(self.handle))?;
+        }
+        Ok(())
+    }
+
+    pub fn start_dhcpc(&self) -> Result<(), EspError> {
+        unsafe {
+            esp!(esp_netif_dhcpc_start(self.handle))?;
+        }
+        Ok(())
+    }
+
+    pub fn set_ip_info(&self, ip_info: ipv4::IpInfo) -> Result<(), EspError> {
+        let esp_ip_info = esp_netif_ip_info_t {
+            gw: Newtype::<esp_ip4_addr_t>::from(ip_info.subnet.gateway).0,
+            ip: Newtype::<esp_ip4_addr_t>::from(ip_info.ip).0,
+            netmask: Newtype::<esp_ip4_addr_t>::from(ip_info.subnet.mask).0,
+        };
+        unsafe { esp!(esp_netif_set_ip_info(self.handle, &esp_ip_info)) }?;
+        Ok(())
+    }
+
     pub fn get_ip_info(&self) -> Result<ipv4::IpInfo, EspError> {
         let mut ip_info = Default::default();
         unsafe { esp!(esp_netif_get_ip_info(self.handle, &mut ip_info)) }?;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [-] I have updated existing examples or added new ones (if applicable).
- - N/A since all ethernet configurations are unique to the board the ESP is used upon.
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
I was testing various aspects on my eth driver and found out `esp-idf` does provide me flexibility when changing from an dhcp environment, but esp-idf-svc layer does not expose all functions of the underlying C library. This commit fixes that.

#### Testing
1. Assign a static IP address to your ethernet device.
2. Ping it using another machine.
3. Start the DHCP client to obtain an ip address from the DHCP server in your network to change the ip to something useful for accessing the internet.
