### PR TITLE
Fixed inconsistent mutability in NVS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix wrong BT configuration version on the c6 (issue #556)
+- Fix inconsistent mutability in NVS (#567)
 
 ### Added
 - OTA: New method - `EspFirmwareInfoLoad::fetch_native` - returning the full native ESP-IDF image descriptor structures

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -330,7 +330,7 @@ impl<T: NvsPartitionId> EspNvs<T> {
         self.len(name).map(|v| v.is_some())
     }
 
-    pub fn remove(&mut self, name: &str) -> Result<bool, EspError> {
+    pub fn remove(&self, name: &str) -> Result<bool, EspError> {
         let c_key = to_cstring_arg(name)?;
 
         // nvs_erase_key is not scoped by datatype
@@ -445,7 +445,7 @@ impl<T: NvsPartitionId> EspNvs<T> {
         }
     }
 
-    pub fn set_raw(&mut self, name: &str, buf: &[u8]) -> Result<bool, EspError> {
+    pub fn set_raw(&self, name: &str, buf: &[u8]) -> Result<bool, EspError> {
         let c_key = to_cstring_arg(name)?;
         let mut u64value: u_int64_t = 0;
 
@@ -514,7 +514,7 @@ impl<T: NvsPartitionId> EspNvs<T> {
         }
     }
 
-    pub fn set_blob(&mut self, name: &str, buf: &[u8]) -> Result<(), EspError> {
+    pub fn set_blob(&self, name: &str, buf: &[u8]) -> Result<(), EspError> {
         let c_key = to_cstring_arg(name)?;
 
         // start by just clearing this key
@@ -568,7 +568,7 @@ impl<T: NvsPartitionId> EspNvs<T> {
         }
     }
 
-    pub fn set_str(&mut self, name: &str, val: &str) -> Result<(), EspError> {
+    pub fn set_str(&self, name: &str, val: &str) -> Result<(), EspError> {
         let c_key = to_cstring_arg(name)?;
         let c_val = to_cstring_arg(val)?;
 


### PR DESCRIPTION
### Submission Checklist 📝
- [-] I have updated existing examples or added new ones (if applicable). 
  - No examples affected
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section. 

### Pull Request Details 📖
Some functions in the NVS interface were left mutable which forced the use of a second mutex from rust. To avoid the need for double locking i removed mutability from these functions. This solution is viable because the C interface is already protected by mutexes and locking from rust should not be necessary. (The majority of the setters are non-mutable currently)
The C lock is visible here: https://github.com/espressif/esp-idf/blob/master/components/nvs_flash/src/nvs_api.cpp#L421

#### Testing
- I double checked that all the affected functions are indeed protected on the C side.
- The functions are working without a mutex from rust.