### PR TITLE
Add functions to start and stop ble scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `use_serde` feature, which enables the `use_serde` feature of `embedded-svc` crate, allowing to deserialize configuration structs.
 - OTA: Allow specifying image size to speed up erase
 - Bluetooth: New methods `EspBleGap::start_scanning` and `EspBleGap::stop_scanning`
+- New example, `bt_ble_gap_scanner` to demonstrate usage of added ble scanning methods
 
 ## [0.51.0] - 2025-01-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OTA: New method - `EspFirmwareInfoLoad::fetch_native` - returning the full native ESP-IDF image descriptor structures
 - Added `use_serde` feature, which enables the `use_serde` feature of `embedded-svc` crate, allowing to deserialize configuration structs.
 - OTA: Allow specifying image size to speed up erase
+- Bluetooth: New methods `EspBleGap::start_scanning` and `EspBleGap::stop_scanning`
 
 ## [0.51.0] - 2025-01-15
 

--- a/examples/bt_ble_gap_scanner.rs
+++ b/examples/bt_ble_gap_scanner.rs
@@ -1,0 +1,159 @@
+//! Example of a BLE GAP scanner using the ESP IDF Bluedroid BLE bindings.
+//! Build with `--features experimental` (for now).
+//!
+//! The example prints discovered ble devices on the console.
+//!
+//! Note that the Buedroid stack consumes a lot of memory, so `sdkconfig.defaults` should be carefully configured
+//! to avoid running out of memory.
+//!
+//! Here's a working configuration, but you might need to adjust further to your concrete use-case:
+//!
+//! CONFIG_BT_ENABLED=y
+//! CONFIG_BT_BLUEDROID_ENABLED=y
+//! CONFIG_BT_CLASSIC_ENABLED=n
+//! CONFIG_BTDM_CTRL_MODE_BLE_ONLY=y
+//! CONFIG_BTDM_CTRL_MODE_BR_EDR_ONLY=n
+//! CONFIG_BTDM_CTRL_MODE_BTDM=n
+//! CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y
+//! CONFIG_BT_BLE_50_FEATURES_SUPPORTED=n
+//! CONFIG_BT_BTC_TASK_STACK_SIZE=15000
+//! CONFIG_BT_BLE_DYNAMIC_ENV_MEMORY=y
+
+#[cfg(all(not(esp32s2), feature = "experimental"))]
+fn main() -> anyhow::Result<()> {
+    example::main()
+}
+
+#[cfg(any(esp32s2, not(feature = "experimental")))]
+fn main() -> anyhow::Result<()> {
+    #[cfg(esp32s2)]
+    panic!("ESP32-S2 does not have a BLE radio");
+
+    #[cfg(not(feature = "experimental"))]
+    panic!("Use `--features experimental` when building this example");
+}
+
+#[cfg(all(not(esp32s2), feature = "experimental"))]
+mod example {
+    use core::fmt;
+    use core::hash::{Hash, Hasher};
+    use std::sync::{Arc, Mutex};
+
+    use esp_idf_svc::bt::ble::gap::{BleGapEvent, EspBleGap};
+    use esp_idf_svc::bt::{BdAddr, Ble, BtDriver};
+    use esp_idf_svc::hal::delay::FreeRtos;
+    use esp_idf_svc::hal::peripherals::Peripherals;
+    use esp_idf_svc::log::EspLogger;
+    use esp_idf_svc::nvs::EspDefaultNvsPartition;
+    use esp_idf_svc::sys::EspError;
+
+    use log::{info, trace, warn};
+
+    pub fn main() -> anyhow::Result<()> {
+        esp_idf_svc::sys::link_patches();
+        EspLogger::initialize_default();
+
+        let peripherals = Peripherals::take()?;
+        let nvs = EspDefaultNvsPartition::take()?;
+
+        let bt = Arc::new(BtDriver::new(peripherals.modem, Some(nvs.clone()))?);
+
+        let server = ExampleServer::new(Arc::new(EspBleGap::new(bt.clone())?));
+
+        info!("BLE Gap initialized");
+
+        let gap_server = server.clone();
+
+        server.gap.subscribe(move |event| {
+            gap_server.check_esp_status(gap_server.on_gap_event(event));
+        })?;
+
+        info!("BLE Gap subscriptions initialized");
+
+        loop {
+            server.start_scanning(0)?;
+            info!("Started ble scanning...");
+
+            FreeRtos::delay_ms(20000);
+            server.stop_scanning()?;
+            info!("Stopped ble scanning.");
+        }
+    }
+
+    // Name the types as they are used in the example to get shorter type signatures in the various functions below.
+    // note that - rather than `Arc`s, you can use regular references as well, but then you have to deal with lifetimes
+    // and the signatures below will not be `'static`.
+    type ExBtDriver = BtDriver<'static, Ble>;
+    type ExEspBleGap = Arc<EspBleGap<'static, Ble, Arc<ExBtDriver>>>;
+
+    #[derive(PartialEq, Eq, Debug, Copy, Clone)]
+    struct BluetoothAddress(BdAddr);
+
+    #[derive(Default)]
+    struct State {
+        discovered: heapless::FnvIndexSet<BluetoothAddress, 64>,
+    }
+
+    #[derive(Clone)]
+    pub struct ExampleServer {
+        gap: ExEspBleGap,
+        state: Arc<Mutex<State>>,
+    }
+
+    impl fmt::Display for BluetoothAddress {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    impl Hash for BluetoothAddress {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            state.write(&self.0.addr())
+        }
+    }
+
+    impl ExampleServer {
+        pub fn new(gap: ExEspBleGap) -> Self {
+            Self {
+                gap,
+                state: Arc::new(Mutex::new(Default::default())),
+            }
+        }
+    }
+
+    impl ExampleServer {
+        fn start_scanning(&self, duration: u32) -> Result<(), EspError> {
+            let mut state = self.state.lock().unwrap();
+            state.discovered.clear();
+
+            self.gap.start_scanning(duration)
+        }
+
+        fn stop_scanning(&self) -> Result<(), EspError> {
+            self.gap.stop_scanning()
+        }
+
+        /// The main event handler for the GAP events
+        fn on_gap_event(&self, event: BleGapEvent) -> Result<(), EspError> {
+            trace!("Got event: {event:?}");
+
+            if let BleGapEvent::ScanResult(result) = event {
+                let mut state = self.state.lock().unwrap();
+                let address = BluetoothAddress(BdAddr::from_bytes(result.bda));
+                match state.discovered.insert(address) {
+                    Ok(true) => info!("Discovered new device {address}"),
+                    Err(_) => warn!("Error while storing address: {address}"),
+                    _ => (),
+                }
+            }
+
+            Ok(())
+        }
+
+        fn check_esp_status(&self, status: Result<(), EspError>) {
+            if let Err(e) = status {
+                warn!("Got status: {:?}", e);
+            }
+        }
+    }
+}

--- a/src/bt/ble/gap.rs
+++ b/src/bt/ble/gap.rs
@@ -656,6 +656,14 @@ where
         esp!(unsafe { esp_ble_set_encryption(&addr.0 as *const _ as *mut _, encryption as u32) })
     }
 
+    pub fn start_scanning(&self, duration: u32) -> Result<(), EspError> {
+        esp!(unsafe { esp_ble_gap_start_scanning(duration) })
+    }
+
+    pub fn stop_scanning(&self) -> Result<(), EspError> {
+        esp!(unsafe { esp_ble_gap_stop_scanning() })
+    }
+
     pub fn start_advertising(&self) -> Result<(), EspError> {
         let mut adv_param: esp_ble_adv_params_t = esp_ble_adv_params_t {
             // TODO


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Add functions to start and stop ble scanning. These functions are required to detect nearby ble devices.

#### Testing
I executed the added example on a esp32c3.
