### PR TITLE
Fix `ScanType` conversion in Wi-Fi configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added argument `subprotocol_list` to `ws_handler` to allow subprotocols to be supported by WebSockets
 
 ### Fixed
+- Fix wrong conversion from `ScanType` to `u32` in Wi-Fi configuration
 - Fix wrong BT configuration version on the c6 (issue #556)
 - Fix inconsistent mutability in NVS (#567)
 - Fix #570 (c_char vs i8 mismatch on newer rustc toolchains)

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -112,7 +112,7 @@ pub mod config {
                     },
                 },
                 channel: s.channel.unwrap_or_default(),
-                scan_type: matches!(s.scan_type, ScanType::Active { .. }).into(),
+                scan_type: matches!(s.scan_type, ScanType::Passive { .. }).into(),
                 show_hidden: s.show_hidden,
                 ..Default::default()
             }


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖
When a `wifi_scan_config_t` is being created from a `ScanConfig`, the `scan_type` is incorrectly converted from a `ScanType` to a `u32`. This also causes the Wi-Fi driver to perform an incorrect type of a scan - opposite to what was specified.

| **`ScanType` variant** | **Value when converted to `u32`** | **Expected `u32` value** |
|---|---|---|
| `Passive` | 0 | 1 |
| `Active` | 1 | 0 |

#### Description
The `match!()` macro will now try to match `ScanType::Passive` instead of `ScanType::Active`, causing it to return `true` if a passive scan is specified. This results in a `0` for an active scan and a `1` for a passive scan.

This also reduces the blocking time by half if `ScanType::default()` is used.

#### Testing
The benchmark test below shows that calling both `EspWifi::start_scan` and `esp_wifi_scan_start()` with a default scan configuration will result in the same performance. The default scan type is a active, according to [this](https://docs.espressif.com/projects/esp-idf/en/v5.3.2/esp32/api-reference/network/esp_wifi.html#_CPPv419esp_wifi_scan_startPK18wifi_scan_config_tb).

Without this change, `EspWifi::start_scan` takes longer, because it performs a passive scan.

<details>
  <summary>Benchmark code</summary>
  
  ```rust
fn main() -> anyhow::Result<()> {
    esp_idf_svc::sys::link_patches();
    EspLogger::initialize_default();

    let peripherals = Peripherals::take()?;
    let sys_loop = EspSystemEventLoop::take()?;
    let nvs = EspDefaultNvsPartition::take()?;

    let wifi = WifiDriver::new(peripherals.modem, sys_loop.clone(), Some(nvs))?;
    esp!(unsafe { esp_wifi_set_storage(wifi_storage_t_WIFI_STORAGE_RAM) })?;
    let mut wifi = EspWifi::wrap_all(
        wifi,
        EspNetif::new(NetifStack::Sta)?,
        EspNetif::new(NetifStack::Ap)?,
    )?;
    wifi.set_configuration(&Configuration::Client(ClientConfiguration::default()))?;
    wifi.start()?;

    scan_with_rust(&mut wifi)?;
    scan_with_esp_esp_wifi_scan_start()?;

    Ok(())
}

fn scan_with_rust(wifi: &mut EspWifi<'static>) -> anyhow::Result<()> {
    let start = Instant::now();
    wifi.start_scan(&ScanConfig::default(), true)?;
    let end = start.elapsed();

    log::info!("EspWifi::start_scan() took: {end:.04?}");
    Ok(())
}

fn scan_with_esp_esp_wifi_scan_start() -> anyhow::Result<()> {
    let start = Instant::now();
    esp!(unsafe { esp_wifi_scan_start(ptr::null(), true) })?;

    let end = start.elapsed();

    log::info!("esp_wifi_scan_start() took: {end:.04?}");
    Ok(())
}
  ```
</details>