### PR TITLE
refactor: add must_use to event loop handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OTA: Allow specifying image size to speed up erase
 - Bluetooth: New methods `EspBleGap::start_scanning` and `EspBleGap::stop_scanning`
 - New example, `bt_ble_gap_scanner` to demonstrate usage of added ble scanning methods
+- Add #[must_use] annotations to event loop types with drop handlers.
 
 ## [0.51.0] - 2025-01-15
 

--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -331,6 +331,7 @@ where
     }
 }
 
+#[must_use = "Event subscription is unregistered when handle is dropped"]
 pub struct EspSubscription<'a, T>
 where
     T: EspEventLoopType,
@@ -486,6 +487,7 @@ where
     }
 }
 
+#[must_use = "Event loop is deleted when handle is dropped"]
 #[derive(Debug)]
 struct EventLoopHandle<T>(T)
 where


### PR DESCRIPTION
This helps catch accidental misuse of the event loop subscription API, wherein a subscription is created and then immediately removed due to the returned handle not being retained.

It causes a compiler warning to be emitted that looks like this:

```
warning: unused `EspSubscription` that must be used
  --> src/wifi.rs:56:9
   |
56 | /         event_loop
57 | |             .subscribe::<WifiEvent, _>({
...  |
90 | |             })
91 | |             .expect("failed to subscribe to event bus");
   | |_______________________________________________________^
   |
   = note: Event subscription is unregistered when handle is dropped
   = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
   |
56 |         let _ = event_loop
   |         +++++++
```

### Submission Checklist 📝
- [N/A] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.