### PR TITLE
Implement `clear` and `iter` functionality for `EspNvs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Thread::init` and `Thread::deinit` are now gone
   - No option to swap the Thread Netif with a custom one, as it complicates the implementation, and I don't see the use-case (unlike with Wifi)
 - MSRV raised to 1.82
+- NVS: Removed `NvsDataType::Any` and replaced `From<nvs_type_t>` with `NvsDataType:from_nvs_type`
 
 ### Fixed
 - Fix wrong conversion from `ScanType` to `u32` in Wi-Fi configuration
@@ -40,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bluetooth: New methods `EspBleGap::start_scanning` and `EspBleGap::stop_scanning`
 - New example, `bt_ble_gap_scanner` to demonstrate usage of added ble scanning methods
 - New example, `mdns_advertise` to demonstrate mDNS service advertisement
+- NVS: Implemented `RawHandle` for `EspNvs<NvsDefault>`
+- NVS: Added `EspNvs::erase_all` to remove all data stored in an nvs namespace
+- NVS: Added `EspNvs::keys` to iterate over all stored keys
 
 ## [0.51.0] - 2025-01-15
 

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -736,6 +736,13 @@ impl RawHandle for EspNvs<NvsEncrypted> {
         self.1
     }
 }
+impl RawHandle for EspNvs<NvsDefault> {
+    type Handle = nvs_handle_t;
+
+    fn handle(&self) -> Self::Handle {
+        self.1
+    }
+}
 
 /// A specialized key-value storage wrapper around `EspNvs` that provides a simplified interface
 /// for storing and retrieving arbitrary data as byte (`u8`) slices.

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -1,4 +1,6 @@
 //! Non-Volatile Storage (NVS)
+#[cfg(esp_idf_version_at_least_5_2_0)]
+use core::marker::PhantomData;
 use core::ptr;
 
 extern crate alloc;
@@ -46,24 +48,25 @@ pub enum NvsDataType {
     I64 = nvs_type_t_NVS_TYPE_I64,
     Str = nvs_type_t_NVS_TYPE_STR,
     Blob = nvs_type_t_NVS_TYPE_BLOB,
-    Any = nvs_type_t_NVS_TYPE_ANY,
 }
 
 #[allow(non_upper_case_globals)]
-impl From<nvs_type_t> for NvsDataType {
-    fn from(nvs_type: nvs_type_t) -> Self {
+impl NvsDataType {
+    /// Converts a `nvs_type_t` to an `NvsDataType`, returning `None` if the type is not recognized.
+    #[must_use]
+    pub fn from_nvs_type(nvs_type: nvs_type_t) -> Option<Self> {
         match nvs_type {
-            nvs_type_t_NVS_TYPE_U8 => NvsDataType::U8,
-            nvs_type_t_NVS_TYPE_I8 => NvsDataType::I8,
-            nvs_type_t_NVS_TYPE_U16 => NvsDataType::U16,
-            nvs_type_t_NVS_TYPE_I16 => NvsDataType::I16,
-            nvs_type_t_NVS_TYPE_U32 => NvsDataType::U32,
-            nvs_type_t_NVS_TYPE_I32 => NvsDataType::I32,
-            nvs_type_t_NVS_TYPE_U64 => NvsDataType::U64,
-            nvs_type_t_NVS_TYPE_I64 => NvsDataType::I64,
-            nvs_type_t_NVS_TYPE_STR => NvsDataType::Str,
-            nvs_type_t_NVS_TYPE_BLOB => NvsDataType::Blob,
-            _ => NvsDataType::Any,
+            nvs_type_t_NVS_TYPE_U8 => Some(Self::U8),
+            nvs_type_t_NVS_TYPE_I8 => Some(Self::I8),
+            nvs_type_t_NVS_TYPE_U16 => Some(Self::U16),
+            nvs_type_t_NVS_TYPE_I16 => Some(Self::I16),
+            nvs_type_t_NVS_TYPE_U32 => Some(Self::U32),
+            nvs_type_t_NVS_TYPE_I32 => Some(Self::I32),
+            nvs_type_t_NVS_TYPE_U64 => Some(Self::U64),
+            nvs_type_t_NVS_TYPE_I64 => Some(Self::I64),
+            nvs_type_t_NVS_TYPE_STR => Some(Self::Str),
+            nvs_type_t_NVS_TYPE_BLOB => Some(Self::Blob),
+            _ => None,
         }
     }
 }
@@ -373,7 +376,7 @@ impl<T: NvsPartitionId> EspNvs<T> {
         let result = unsafe { nvs_find_key(self.1, c_key.as_ptr(), &mut entry_type as *mut _) };
 
         match result {
-            ESP_OK => Ok(Some(NvsDataType::from(entry_type))),
+            ESP_OK => Ok(NvsDataType::from_nvs_type(entry_type)),
             ESP_ERR_NVS_NOT_FOUND => Ok(None),
             err => {
                 esp!(err)?;
@@ -710,7 +713,7 @@ impl<T: NvsPartitionId> EspNvs<T> {
     }
 
     /// Erases all key-value pairs in the NVS namespace.
-    /// 
+    ///
     /// # Errors
     ///
     /// This function will return an error if the NVS erase operation fails, this can happen because of
@@ -723,6 +726,56 @@ impl<T: NvsPartitionId> EspNvs<T> {
         esp!(unsafe { nvs_commit(self.1) })?;
 
         Ok(())
+    }
+
+    /// Returns struct to iterate over all keys stored in this NVS namespace with the specified data type.
+    ///
+    /// A data type of `None` will return all keys regardless of their type.
+    ///
+    /// # Mutating the NVS while iterating
+    ///
+    /// Both this function and others that mutate the NVS like [`EspNvs::remove`] only require an immutable
+    /// reference, making it possible to mutate the NVS while iterating over it. For example, one could remove
+    /// keys while iterating.
+    ///
+    /// It is **not** recommended to do this, because the iterator might skip keys. It will not result in
+    /// a panic or undefinied behavior.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if
+    /// - there is no memory available for allocation of internal structures
+    /// - for some reason the [`EspNvs::handle`] is invalid (should not happen)
+    #[cfg(esp_idf_version_at_least_5_2_0)]
+    pub fn keys(&self, data_type: Option<NvsDataType>) -> Result<EspNvsKeys<'_>, EspError> {
+        let mut raw_iter: nvs_iterator_t = core::ptr::null_mut();
+
+        match unsafe {
+            nvs_entry_find_in_handle(
+                self.1,
+                data_type
+                    .map(|ty| ty as u32)
+                    .unwrap_or(nvs_type_t_NVS_TYPE_ANY),
+                &mut raw_iter as *mut _,
+            )
+        } {
+            ESP_ERR_NVS_NOT_FOUND => {
+                return Ok(EspNvsKeys {
+                    _nvs: PhantomData,
+                    raw_iter: core::ptr::null_mut(),
+                    is_exhausted: true,
+                    key_name_buffer: [0; 16],
+                });
+            }
+            other => esp!(other)?,
+        }
+
+        Ok(EspNvsKeys {
+            _nvs: PhantomData,
+            raw_iter,
+            is_exhausted: false,
+            key_name_buffer: [0; 16],
+        })
     }
 }
 
@@ -757,6 +810,73 @@ impl RawHandle for EspNvs<NvsDefault> {
 
     fn handle(&self) -> Self::Handle {
         self.1
+    }
+}
+
+#[cfg(esp_idf_version_at_least_5_2_0)]
+pub struct EspNvsKeys<'a> {
+    // The EspNvs must not be dropped while the iterator is still in use,
+    // this reference ensures that.
+    _nvs: PhantomData<&'a ()>,
+    raw_iter: nvs_iterator_t,
+    is_exhausted: bool,
+    key_name_buffer: [u8; 16],
+}
+
+#[cfg(esp_idf_version_at_least_5_2_0)]
+impl<'a> EspNvsKeys<'a> {
+    /// Returns the next key in the NVS namespace and its data type.
+    ///
+    /// After the last key is returned, this function will return `None` on subsequent calls.
+    pub fn next_key(&mut self) -> Option<(&str, NvsDataType)> {
+        if self.is_exhausted || self.raw_iter.is_null() {
+            return None;
+        }
+
+        let mut info: nvs_entry_info_t = Default::default();
+        match unsafe { nvs_entry_info(self.raw_iter, &mut info as *mut _) } {
+            ESP_ERR_NVS_NOT_FOUND => {
+                self.is_exhausted = true;
+                None
+            }
+            ESP_OK => {
+                // For the next iteration, the iterator must be advanced to the next entry,
+                // otherwise it will return the same entry again.
+                //
+                // This function call will fail if the iterator is
+                // - null, which is checked before this call
+                // - exhausted (if it is, it will set self.raw_iter to null and iteration will stop)
+                //
+                // For convenience, the error is ignored here, because it should never happen anyway.
+                // The usage example in C simply stops the iteration on error too and does not do any
+                // error handling.
+                let _ = esp!(unsafe { nvs_entry_next(&mut self.raw_iter as *mut _) });
+
+                // Copy the current key name into the buffer to make a str
+                // that lives for the lifetime of the &mut self borrow.
+                self.key_name_buffer[..info.key.len()].copy_from_slice(&info.key[..]);
+
+                Some((
+                    from_cstr(&self.key_name_buffer[..info.key.len()]),
+                    NvsDataType::from_nvs_type(info.type_).expect("Unknown NVS data type"),
+                ))
+            }
+            // The nvs_entry_info only fails if any of the arguments are null.
+            // The nvs_entry_info is never null, and self.raw_iter is checked for null before the invocation.
+            //
+            // Therefore this should never happen.
+            err => unreachable!(
+                "Unexpected error while iterating over NVS entries: {:?}",
+                esp!(err)
+            ),
+        }
+    }
+}
+
+#[cfg(esp_idf_version_at_least_5_2_0)]
+impl<'a> Drop for EspNvsKeys<'a> {
+    fn drop(&mut self) {
+        unsafe { nvs_release_iterator(self.raw_iter) };
     }
 }
 

--- a/src/nvs.rs
+++ b/src/nvs.rs
@@ -708,6 +708,22 @@ impl<T: NvsPartitionId> EspNvs<T> {
 
         Ok(())
     }
+
+    /// Erases all key-value pairs in the NVS namespace.
+    /// 
+    /// # Errors
+    ///
+    /// This function will return an error if the NVS erase operation fails, this can happen because of
+    /// - a corrupted NVS partition
+    /// - the NVS is opened in read-only mode
+    /// - other internal errors from the underlying storage driver
+    pub fn erase_all(&self) -> Result<(), EspError> {
+        esp!(unsafe { nvs_erase_all(self.1) })?;
+
+        esp!(unsafe { nvs_commit(self.1) })?;
+
+        Ok(())
+    }
 }
 
 impl<T: NvsPartitionId> Drop for EspNvs<T> {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-svc/blob/main/esp-idf-svc/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

This PR adds support for:

##### 1. Obtaining a handle for `EspNvs<Default>`

I guess this was forgotten? It is nice to have when calling `esp-idf-sys` functions.

##### 2. Added `EspNvs::clear`

I use a library that stores some data in the `EspNvs`, and I want to empty all stored data in some circumstances. Previously there wasn't any functionality to accomplish that, which is why I made this PR.

##### 3. Added `EspNvs::iter`

This function allows iterating over all stored keys. I don't need this function, but #340 requests this function and the `erase_all`, so I added it to close that issue with this PR

Regarding the implementation: It seems to work, but I don't know how the API should look like, couldn't find many references.

The main reference was [this example in the esp-idf docs](https://docs.espressif.com/projects/esp-idf/en/v5.5/esp32/api-reference/storage/nvs_flash.html#_CPPv424nvs_entry_find_in_handle12nvs_handle_t10nvs_type_tP14nvs_iterator_t):
```C
// Example of listing all the key-value pairs of any type under specified handle (which defines a partition and namespace)
 nvs_iterator_t it = NULL;
 esp_err_t res = nvs_entry_find_in_handle(<nvs_handle>, NVS_TYPE_ANY, &it);
 while(res == ESP_OK) {
nvs_entry_info_t info;
     nvs_entry_info(it, &info); // Can omit error check if parameters are guaranteed to be non-NULL
     printf("key '%s', type '%d' \n", info.key, info.type);
     res = nvs_entry_next(&it);
 }
 nvs_release_iterator(it);
```
The current code replicates the functionality, ignoring any errors that occur while iterating.

I do not know whether this is desirable or not.

#### Testing

Used it in a separate project, uploaded to the ESP32 and checked for any crashes.


----


This PR closes #340.